### PR TITLE
fix: highlight delays by updating on slot packets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [pull_request, push]
+on: [push]
 
 jobs:
   build:

--- a/src/main/java/com/github/synnerz/devonian/mixin/ClientCommonPacketListenerImplMixin.java
+++ b/src/main/java/com/github/synnerz/devonian/mixin/ClientCommonPacketListenerImplMixin.java
@@ -15,6 +15,6 @@ public class ClientCommonPacketListenerImplMixin {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/network/PacketProcessor;)V", shift = At.Shift.AFTER)
     )
     private void devonian$clientThreadServerTick(ClientboundPingPacket clientboundPingPacket, CallbackInfo ci) {
-        new ClientThreadServerTickEvent().post();
+        if (clientboundPingPacket.getId() < 0) new ClientThreadServerTickEvent().post();
     }
 }

--- a/src/main/java/com/github/synnerz/devonian/mixin/KeyboardInputMixin.java
+++ b/src/main/java/com/github/synnerz/devonian/mixin/KeyboardInputMixin.java
@@ -1,0 +1,18 @@
+package com.github.synnerz.devonian.mixin;
+
+import com.github.synnerz.devonian.features.misc.AutoSprint;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.player.KeyboardInput;
+import net.minecraft.world.entity.player.Input;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(KeyboardInput.class)
+public class KeyboardInputMixin {
+    @WrapOperation(method = "tick", at = @At(value = "NEW", target = "(ZZZZZZZ)Lnet/minecraft/world/entity/player/Input;"))
+    private Input devonian$onInputTick(boolean up, boolean down, boolean left, boolean right, boolean jump, boolean shift, boolean sprint, Operation<Input> original) {
+        if (!AutoSprint.INSTANCE.isEnabled()) return original.call(up, down, left, right, jump, shift, sprint);
+        return original.call(up, down, left, right, jump, shift, true);
+    }
+}

--- a/src/main/java/com/github/synnerz/devonian/mixin/MinecraftMixin.java
+++ b/src/main/java/com/github/synnerz/devonian/mixin/MinecraftMixin.java
@@ -1,5 +1,6 @@
 package com.github.synnerz.devonian.mixin;
 
+import com.github.synnerz.devonian.api.Scheduler;
 import com.github.synnerz.devonian.api.events.*;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -17,6 +18,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -74,5 +76,13 @@ public class MinecraftMixin {
     )
     private void devonian$onRenderTick(boolean tick, CallbackInfo ci) {
         new RenderTickEvent().post();
+    }
+
+    @Inject(
+        method = "runTick",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketProcessor;processQueuedPackets()V")
+    )
+    private void devonian$schedulerBeforePacket(boolean bl, CallbackInfo ci) {
+        Scheduler.INSTANCE.internalListener();
     }
 }

--- a/src/main/java/com/github/synnerz/devonian/mixin/accessor/ClientboundMoveEntityPacketAccessor.java
+++ b/src/main/java/com/github/synnerz/devonian/mixin/accessor/ClientboundMoveEntityPacketAccessor.java
@@ -1,0 +1,11 @@
+package com.github.synnerz.devonian.mixin.accessor;
+
+import net.minecraft.network.protocol.game.ClientboundMoveEntityPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientboundMoveEntityPacket.class)
+public interface ClientboundMoveEntityPacketAccessor {
+    @Accessor("entityId")
+    int getEntityId();
+}

--- a/src/main/java/com/github/synnerz/devonian/mixin/accessor/GlTextureAccessor.java
+++ b/src/main/java/com/github/synnerz/devonian/mixin/accessor/GlTextureAccessor.java
@@ -1,0 +1,11 @@
+package com.github.synnerz.devonian.mixin.accessor;
+
+import com.mojang.blaze3d.opengl.GlTexture;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(GlTexture.class)
+public interface GlTextureAccessor {
+    @Accessor("modesDirty")
+    void setModesDirty(boolean dirty);
+}

--- a/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
@@ -273,6 +273,7 @@ object Devonian : ClientModInitializer {
         SharpShooterSolver,
         SelectedItemNameRender,
         PositionMessages,
+        AutoSprint,
 
         // Debug
         CopyItem,

--- a/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
@@ -275,6 +275,7 @@ object Devonian : ClientModInitializer {
         PositionMessages,
         AutoSprint,
         CampHelper,
+        TerminalDisplay,
 
         // Debug
         CopyItem,

--- a/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
@@ -276,6 +276,7 @@ object Devonian : ClientModInitializer {
         AutoSprint,
         CampHelper,
         TerminalDisplay,
+        PartyFinderOverview,
 
         // Debug
         CopyItem,

--- a/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/Devonian.kt
@@ -274,6 +274,7 @@ object Devonian : ClientModInitializer {
         SelectedItemNameRender,
         PositionMessages,
         AutoSprint,
+        CampHelper,
 
         // Debug
         CopyItem,

--- a/src/main/kotlin/com/github/synnerz/devonian/api/Scheduler.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/Scheduler.kt
@@ -4,6 +4,7 @@ import com.github.synnerz.devonian.api.events.ClientThreadServerTickEvent
 import com.github.synnerz.devonian.api.events.EventBus
 import kotlinx.atomicfu.atomic
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.PriorityBlockingQueue
 
@@ -14,6 +15,7 @@ object Scheduler {
     private val tasksServer = PriorityBlockingQueue<Task>(10, taskComp)
     private var tickServer = atomic(0)
     private var taskId = atomic(0)
+    private val beforePacketTasks = ConcurrentLinkedQueue<() -> Unit>()
 
     val schedulePool = Executors.newScheduledThreadPool(0)
 
@@ -44,5 +46,17 @@ object Scheduler {
     @JvmOverloads
     fun scheduleServerTask(delay: Int = 1, cb: () -> Unit) {
         tasksServer.add(Task(tickServer.value + delay, cb, taskId.incrementAndGet()))
+    }
+
+    fun scheduleBeforePacket(cb: () -> Unit) {
+        beforePacketTasks.offer(cb)
+    }
+
+    fun internalListener() {
+        var l = beforePacketTasks.size
+        while (--l >= 0) {
+            val cb = beforePacketTasks.poll() ?: break
+            cb()
+        }
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/api/bufimgrenderer/BufferedImageUploader.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/bufimgrenderer/BufferedImageUploader.kt
@@ -3,6 +3,7 @@ package com.github.synnerz.devonian.api.bufimgrenderer
 import com.github.synnerz.devonian.Devonian
 import com.github.synnerz.devonian.api.events.EventBus
 import com.github.synnerz.devonian.api.events.PostClientInit
+import com.github.synnerz.devonian.mixin.accessor.GlTextureAccessor
 import com.mojang.blaze3d.opengl.GlStateManager
 import com.mojang.blaze3d.opengl.GlTexture
 import com.mojang.blaze3d.systems.RenderSystem
@@ -28,6 +29,7 @@ class BufferedImageUploader(val name: String) : AbstractTexture() {
         w = img.width
         h = img.height
         texture = RenderSystem.getDevice().createTexture(name, 0, TextureFormat.RGBA8, w, h, 1, 1)
+        (texture as? GlTextureAccessor)?.setModesDirty(false)
         textureView = RenderSystem.getDevice().createTextureView(texture!!, 0, 1)
         texId = (texture as GlTexture).glId()
         GlStateManager._bindTexture(texId)

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Coordinates.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Coordinates.kt
@@ -35,6 +35,12 @@ data class ComponentPosition(val x: Int, val z: Int) {
 
     fun withWorld() = toWorld().let { WorldComponentPosition(it.x, it.z, x, z) }
 
+    fun toRoom() =
+        ComponentPosition(
+            x and (1.inv()),
+            z and (1.inv()),
+        )
+
     fun isValid() = x in 0 .. 10 && z in 0 .. 10
     fun isValidRoom() = (x and 1) == 0 && (z and 1) == 0
     fun isValidDoor() = ((x and 1) xor (z and 1)) == 1

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonMapScanner.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonMapScanner.kt
@@ -189,7 +189,10 @@ object DungeonMapScanner {
                 MapColors.ROOM_TRAP.color -> RoomTypes.TRAP
                 else -> RoomTypes.UNKNOWN
             }
-            if (!room.explored) room.explored = roomCol != MapColors.ROOM_UNOPENED.color
+            if (!room.explored) {
+                room.explored = roomCol != MapColors.ROOM_UNOPENED.color
+                if (room.explored) Dungeons.totalRoomSecrets.value -= room.totalSecrets
+            }
 
             if (room.checkmark != CheckmarkTypes.GREEN) {
                 room.checkmark = if (roomCol == centerCol) CheckmarkTypes.NONE

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonMapScanner.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonMapScanner.kt
@@ -191,7 +191,7 @@ object DungeonMapScanner {
             }
             if (!room.explored) {
                 room.explored = roomCol != MapColors.ROOM_UNOPENED.color
-                if (room.explored) Dungeons.totalRoomSecrets.value -= room.totalSecrets
+                if (room.explored) Dungeons.totalRoomSecrets.value += room.totalSecrets
             }
 
             if (room.checkmark != CheckmarkTypes.GREEN) {

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonScanner.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonScanner.kt
@@ -178,7 +178,7 @@ object DungeonScanner {
 
             currentRoom = rooms[jdx]
             if (currentRoom != null && !currentRoom!!.explored)
-                Dungeons.totalRoomSecrets.value -= currentRoom!!.totalSecrets
+                Dungeons.totalRoomSecrets.value += currentRoom!!.totalSecrets
             currentRoom?.explored = true
 
             if (lastIdx == jdx) return@on
@@ -393,13 +393,6 @@ object DungeonScanner {
             return@removeIf true
         }
 
-        if (availablePos.size != startLen) {
-            DungeonMap.redrawMap(rooms.toList(), doors.toList())
-            Dungeons.totalRoomSecrets.value = 0
-            rooms.toSet().forEach {
-                if (it == null || it.explored) return@forEach
-                Dungeons.totalRoomSecrets.value += it.totalSecrets
-            }
-        }
+        if (availablePos.size != startLen) DungeonMap.redrawMap(rooms.toList(), doors.toList())
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonScanner.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/DungeonScanner.kt
@@ -177,6 +177,8 @@ object DungeonScanner {
                 DungeonEvent.RoomLeave(currentRoom, lastIdx!!).post()
 
             currentRoom = rooms[jdx]
+            if (currentRoom != null && !currentRoom!!.explored)
+                Dungeons.totalRoomSecrets.value -= currentRoom!!.totalSecrets
             currentRoom?.explored = true
 
             if (lastIdx == jdx) return@on
@@ -391,6 +393,13 @@ object DungeonScanner {
             return@removeIf true
         }
 
-        if (availablePos.size != startLen) DungeonMap.redrawMap(rooms.toList(), doors.toList())
+        if (availablePos.size != startLen) {
+            DungeonMap.redrawMap(rooms.toList(), doors.toList())
+            Dungeons.totalRoomSecrets.value = 0
+            rooms.toSet().forEach {
+                if (it == null || it.explored) return@forEach
+                Dungeons.totalRoomSecrets.value += it.totalSecrets
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Dungeons.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Dungeons.kt
@@ -69,6 +69,7 @@ object Dungeons {
     val inBoss = BasicState(false)
     val bloodCleared = BasicState(false)
     val started = BasicState(false)
+    val totalRoomSecrets = BasicState(0)
 
     private fun fuckEntrance(score: State<Double>) =
         score.zip(floorState) { score, floor -> (score * (if (floor == FloorType.Entrance) 0.7 else 1.0)).toInt() }

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Dungeons.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Dungeons.kt
@@ -146,7 +146,7 @@ object Dungeons {
         .zip(speedScore) { a, b -> a + b }
         .zip(bonusScore) { a, b -> a + b }
 
-    val _targetScore = floorState.zip(isPaul) { floor, paul -> 40 - (1 + (if (floor.floorNum >= 6) 7 else 5) + (if (paul) 10 else 0)) }
+    val _targetScore = bonusScore_.map { 40 - it }
     val minSecrets = _targetScore.zip(totalSecretsRequired) { score, secrets -> ceil(score * secrets / 40.0).toInt() }
     val remainingMinSecrets = minSecrets.zip(secretsFound) { total, found -> max(0, total - found) }
 

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Dungeons.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Dungeons.kt
@@ -422,6 +422,7 @@ object Dungeons {
         inBoss.value = false
         bloodCleared.value = false
         started.value = false
+        totalRoomSecrets.value = 0
 
         totalRoomHisto.clear()
     }

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/PartyFinderListener.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/PartyFinderListener.kt
@@ -1,0 +1,177 @@
+package com.github.synnerz.devonian.api.dungeon
+
+import com.github.synnerz.devonian.api.ItemUtils
+import com.github.synnerz.devonian.api.ScreenUtils
+import com.github.synnerz.devonian.api.events.*
+import com.github.synnerz.devonian.features.dungeons.PartyFinderHighlight.minecraft
+import com.github.synnerz.devonian.utils.StringUtils
+import net.minecraft.world.item.Items
+import java.util.concurrent.CopyOnWriteArrayList
+
+object PartyFinderListener {
+    private val TYPE_REGEX = "^Dungeon: (Master Mode )?(The Catacombs)$".toRegex()
+    private val FLOOR_REGEX = "^Floor: Floor ([IV]+)$".toRegex()
+    private val TAB_ROLE_REGEX = "^ (Healer|Tank|Mage|Berserk|Archer) (\\d+)(?:: [\\d.,]+%)?$".toRegex()
+    private val USER_ROLE_REGEX = "^ (\\w{1,16}): (Healer|Tank|Mage|Berserk|Archer) \\((\\d+)\\)$".toRegex()
+    private val LOW_CATA_REGEX = "^Requires Catacombs Level \\d+!$".toRegex()
+    private val LOW_ROLE_REGEX = "^Requires a Class at Level \\d+!$".toRegex()
+    private val CANNOT_JOIN_REGEX = "^Complete previous floor first!$".toRegex()
+    private val CURRENTLY_SELECTED_REGEX = "^Currently Selected: (Healer|Tank|Mage|Berserk|Archer)$".toRegex()
+    private val CHAT_ROLE_REGEX = "^You have selected the (Healer|Tank|Mage|Berserk|Archer) Dungeon Class!$".toRegex()
+    private val CHAT_REFRESH_CD_REGEX = "^Please wait a few seconds between refreshing!$".toRegex()
+    private val CHAT_REFRESHING_REGEX = "^Refreshing\\.\\.\\.$".toRegex()
+    private val parties = CopyOnWriteArrayList<PartyFinderData>()
+    private val oldParties = CopyOnWriteArrayList<PartyFinderData>()
+    private var inPF = false
+    private var inGate = false
+    private var shouldScan = false
+    private var currentRole: String? = null
+
+    class PartyFinderEvent(
+        val parties: CopyOnWriteArrayList<PartyFinderData>
+    ) : Event()
+
+    data class PartyFinderMember(val name: String, val role: String, val level: Int)
+
+    data class PartyFinderData(
+        var floor: Int = -1,
+        var idx: Int,
+        var isMasterMode: Boolean = false,
+        val members: MutableList<PartyFinderMember> = mutableListOf(),
+        // maybe we need this data later or something idk commenting for now
+//        var note: String = "Empty",
+//        var requiredLevel: Int = -1,
+//        var requiredRoleLevel: Int = -1,
+        var canJoin: PartyFinderStatus = PartyFinderStatus.CAN_JOIN,
+    )
+
+    fun initialize() {
+        EventBus.on<ServerContainerOpen> { event ->
+            inPF = event.string() == "Party Finder"
+            shouldScan = inPF
+            inGate = event.string() == "Catacombs Gate"
+            if (!inPF && parties.isNotEmpty()) {
+                parties.clear()
+                PartyFinderEvent(parties).post()
+            }
+        }
+
+        EventBus.on<ServerContainerClose> {
+            if (parties.isNotEmpty()) reset()
+        }
+
+        EventBus.on<ClientContainerClose> {
+            if (parties.isNotEmpty()) reset()
+        }
+
+        EventBus.on<ChatEvent> { event ->
+            event.matches(CHAT_REFRESH_CD_REGEX)?.let {
+                parties.clear()
+                parties.addAll(oldParties)
+                PartyFinderEvent(parties).post()
+                return@on
+            }
+        }
+
+        EventBus.on<GuiClickEvent> { event ->
+            if (!inPF) return@on
+            val slot = ScreenUtils.cursorSlot(event.screen) ?: return@on
+            if (slot.containerSlot != 46 || slot.container == minecraft.player?.inventory) return@on
+
+            parties.clear()
+            PartyFinderEvent(parties).post()
+            shouldScan = true
+        }
+
+        EventBus.on<ServerContainerSetContent> { event ->
+            if (inGate) {
+                val starSlot = event.items.getOrNull(45) ?: return@on
+                val lore = ItemUtils.lore(starSlot) ?: return@on
+                for (line in lore) {
+                    val match = CURRENTLY_SELECTED_REGEX.matchEntire(line)?.groupValues?.drop(1) ?: continue
+                    currentRole = match[0]
+                }
+                inGate = false
+                return@on
+            }
+
+            if (!shouldScan) return@on
+
+            event.forEach { idx, itemStack ->
+                if (itemStack == null || itemStack.item != Items.PLAYER_HEAD) return@forEach
+
+                val lore = ItemUtils.lore(itemStack) ?: return@forEach
+                var currentData: PartyFinderData? = null
+
+                for (line in lore) {
+                    if (currentData == null) {
+                        val typeMatch = TYPE_REGEX.matchEntire(line)?.groupValues?.drop(1) ?: continue
+                        currentData = PartyFinderData(idx = idx, isMasterMode = typeMatch[0] == "Master Mode ")
+                        continue
+                    }
+                    if (LOW_CATA_REGEX.matches(line)) {
+                        currentData.canJoin = PartyFinderStatus.LOW_CATA
+                        continue
+                    }
+                    if (LOW_ROLE_REGEX.matches(line)) {
+                        currentData.canJoin = PartyFinderStatus.LOW_ROLE
+                        continue
+                    }
+                    if (CANNOT_JOIN_REGEX.matches(line)) {
+                        currentData.canJoin = PartyFinderStatus.CANNOT_JOIN
+                        continue
+                    }
+                    if (currentData.floor == -1) {
+                        val floorMatch = FLOOR_REGEX.matchEntire(line)?.groupValues?.drop(1) ?: continue
+                        currentData.floor = StringUtils.parseRoman(floorMatch[0])
+                        continue
+                    }
+
+                    val ( username, role, level ) = USER_ROLE_REGEX.matchEntire(line)?.groupValues?.drop(1) ?: continue
+
+                    currentData.members.add(PartyFinderMember(
+                        username,
+                        role,
+                        level.toIntOrNull() ?: 0
+                    ))
+                }
+
+                if (
+                    currentData != null &&
+                    currentData.canJoin == PartyFinderStatus.CAN_JOIN &&
+                    currentData.members.any { it.role == currentRole }
+                ) currentData.canJoin = PartyFinderStatus.DUPE_CLASS
+
+                if (currentData == null) return@forEach
+
+                parties.add(currentData)
+                oldParties.add(currentData)
+            }
+
+            PartyFinderEvent(parties).post()
+            shouldScan = false
+        }
+
+        EventBus.on<WorldChangeEvent> {
+            reset()
+        }
+    }
+
+    private fun reset() {
+        parties.clear()
+        oldParties.clear()
+        inPF = false
+        shouldScan = false
+        inGate = false
+        currentRole = null
+        PartyFinderEvent(parties).post()
+    }
+
+    enum class PartyFinderStatus {
+        CAN_JOIN,
+        CANNOT_JOIN, // SHOULD be, hasn't completed previous floor
+        DUPE_CLASS,
+        LOW_CATA,
+        LOW_ROLE,
+    }
+}

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/PartyFinderListener.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/PartyFinderListener.kt
@@ -12,7 +12,7 @@ object PartyFinderListener {
     private val TYPE_REGEX = "^Dungeon: (Master Mode )?(The Catacombs)$".toRegex()
     private val FLOOR_REGEX = "^Floor: Floor ([IV]+)$".toRegex()
     private val TAB_ROLE_REGEX = "^ (Healer|Tank|Mage|Berserk|Archer) (\\d+)(?:: [\\d.,]+%)?$".toRegex()
-    private val USER_ROLE_REGEX = "^ (\\w{1,16}): (Healer|Tank|Mage|Berserk|Archer) \\((\\d+)\\)$".toRegex()
+    val USER_ROLE_REGEX = "^ (\\w{1,16}): (Healer|Tank|Mage|Berserk|Archer) \\((\\d+)\\)$".toRegex()
     private val LOW_CATA_REGEX = "^Requires Catacombs Level \\d+!$".toRegex()
     private val LOW_ROLE_REGEX = "^Requires a Class at Level \\d+!$".toRegex()
     private val CANNOT_JOIN_REGEX = "^Complete previous floor first!$".toRegex()

--- a/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Stages.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/dungeon/Stages.kt
@@ -12,12 +12,7 @@ object Stages {
     val Clear: SplitStage
 
     val BloodOpen = SplitStage().withName("&4Blood").withLongTime()
-    val FirstWatcherSpawn = SequentialSplitStage(
-        arrayOf(
-            SplitStage().withName("&cFirst Spawn").withLongTime(),
-            SplitStage("[BOSS] The Watcher: Let's see how you can handle this.")
-        )
-    )
+    val FirstWatcherSpawn = SplitStage().withName("&cFirst Spawn").withLongTime()
     val WatcherClear = SplitStage().withName("&cWatcher").withLongTime()
     val PortalEnter = SplitStage("[BOSS] The Watcher: You have proven yourself. You may pass.")
         .withName("&dPortal Enter").withLongTime()
@@ -61,7 +56,17 @@ object Stages {
                 SequentialSplitStage(
                     arrayOf(
                         BloodOpen,
-                        SplitStage("The BLOOD DOOR has been opened!", arrayOf(FirstWatcherSpawn, WatcherClear)),
+                        SplitStage(
+                            "The BLOOD DOOR has been opened!", arrayOf(
+                                SequentialSplitStage(
+                                    arrayOf(
+                                        FirstWatcherSpawn,
+                                        SplitStage("[BOSS] The Watcher: Let's see how you can handle this.")
+                                    )
+                                ),
+                                WatcherClear
+                            )
+                        ),
                         PortalEnter
                     )
                 ),
@@ -208,10 +213,12 @@ class TerminalSection(val terms: Int, val section: Int) : SplitStage() {
                             else if (!Stages.S2.deviceDone) Stages.S2.deviceDone = true
                             else Stages.S3.deviceDone = true
                         }
+
                         2 -> {
                             if (!Stages.S3.deviceDone) Stages.S3.deviceDone = true
                             else Stages.S4.deviceDone = true
                         }
+
                         3 -> Stages.S4.deviceDone = true
                     }
                     return

--- a/src/main/kotlin/com/github/synnerz/devonian/api/events/Event.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/events/Event.kt
@@ -34,6 +34,7 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.HitResult
+import net.minecraft.world.phys.Vec3
 
 @Target(AnnotationTarget.CLASS)
 annotation class Threaded
@@ -332,6 +333,7 @@ class RenderTickEvent : Event()
 @Threaded class EntityEquipmentEvent(
     val entityId: Int,
     val type: EntityType<*>,
+    val spawnPos: Vec3,
     val slots: List<Pair<EquipmentSlot, ItemStack?>>
 ) : Event()
 

--- a/src/main/kotlin/com/github/synnerz/devonian/api/events/EventBus.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/api/events/EventBus.kt
@@ -18,6 +18,7 @@ import net.minecraft.network.syncher.SynchedEntityData
 import net.minecraft.sounds.SoundEvent
 import net.minecraft.sounds.SoundSource
 import net.minecraft.world.entity.EntityType
+import net.minecraft.world.phys.Vec3
 import org.lwjgl.glfw.GLFW
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -31,6 +32,7 @@ object EventBus {
     private val teamRegex = "^team_(\\d+)$".toRegex()
     val events = ConcurrentHashMap<KClass<*>, MutableList<EventListener<Event>>>()
     private val entityTypes = mutableMapOf<Int, EntityType<*>>()
+    private val entityPos = mutableMapOf<Int, Vec3>()
 
     init {
         ClientEntityEvents.ENTITY_LOAD.register { entity, _ ->
@@ -47,6 +49,7 @@ object EventBus {
             WorldChangeEvent(mc, world).post()
             totalTicks = 0
             entityTypes.clear()
+            entityPos.clear()
         }
         ScreenEvents.BEFORE_INIT.register { _, screen, _, _ ->
             ScreenMouseEvents.allowMouseClick(screen).register { _, event ->
@@ -163,6 +166,7 @@ object EventBus {
                     val id = packet.id
                     val type = packet.type
                     entityTypes[id] = type
+                    entityPos[id] = Vec3(packet.x, packet.y, packet.z)
                 }
 
                 is ClientboundSetEntityDataPacket -> {
@@ -184,10 +188,12 @@ object EventBus {
                 is ClientboundSetEquipmentPacket -> {
                     val id = packet.entity
                     val type = entityTypes[id] ?: return@on
+                    val pos = entityPos[id] ?: return@on
                     EntityEquipmentEvent(
                         id,
                         type,
-                        packet.slots.map { Pair(it.first, it.second) }
+                        pos,
+                        packet.slots.map { Pair(it.first, it.second) },
                     ).post()
                 }
 

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/CroesusHighlightUnopened.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/CroesusHighlightUnopened.kt
@@ -1,7 +1,6 @@
 package com.github.synnerz.devonian.features.dungeons
 
 import com.github.synnerz.devonian.api.ItemUtils
-import com.github.synnerz.devonian.api.Scheduler
 import com.github.synnerz.devonian.api.events.PacketReceivedEvent
 import com.github.synnerz.devonian.api.events.PacketSentEvent
 import com.github.synnerz.devonian.api.events.RenderSlotEvent
@@ -10,11 +9,13 @@ import com.github.synnerz.devonian.config.Categories
 import com.github.synnerz.devonian.features.Feature
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import java.awt.Color
+import java.util.concurrent.CopyOnWriteArraySet
 
 object CroesusHighlightUnopened : Feature(
     "croesusHighlightUnopened",
@@ -30,59 +31,53 @@ object CroesusHighlightUnopened : Feature(
         "Croesus Highlight Blacklist"
     )
     private var inCroesus = false
-    private val whitelist = mutableListOf<Int>()
-    private val blacklist = mutableListOf<Int>()
+    private val whitelist = CopyOnWriteArraySet<Int>()
+    private val blacklist = CopyOnWriteArraySet<Int>()
 
     override fun initialize() {
         on<PacketReceivedEvent> { event ->
             val packet = event.packet
 
-            if (packet is ClientboundOpenScreenPacket) {
-                val title = packet.title.string
-                inCroesus = title == "Croesus"
-                return@on
-            }
+            when (packet) {
+                is ClientboundOpenScreenPacket -> {
+                    val title = packet.title.string
+                    inCroesus = title == "Croesus"
+                    whitelist.clear()
+                    blacklist.clear()
+                    return@on
+                }
 
-            if (packet is ClientboundContainerClosePacket) {
-                Scheduler.scheduleTask {
+                is ClientboundContainerClosePacket -> {
+                    inCroesus = false
                     blacklist.clear()
                     whitelist.clear()
+                    return@on
                 }
-                return@on
-            }
 
-            if (packet !is ClientboundContainerSetContentPacket) return@on
-            if (!inCroesus) return@on
-
-            val items = packet.items
-            for (idx in 0..<45) {
-                val itemStack = items.getOrNull(idx) ?: continue
-                if (itemStack == ItemStack.EMPTY) continue
-                if (itemStack.item != Items.PLAYER_HEAD) continue
-                val lore = ItemUtils.lore(itemStack) ?: continue
-
-                for (line in lore) {
-                    if (line.contains("Opened Chest: ")) {
-                        Scheduler.scheduleTask { blacklist.add(idx) }
-                        continue
+                is ClientboundContainerSetContentPacket -> {
+                    if (!inCroesus) return@on
+                    val items = packet.items
+                    for (idx in 0..<45) {
+                        updateSlotHighlight(idx, items.getOrNull(idx))
                     }
-                    if (line != "No chests opened yet!") continue
+                }
 
-                    Scheduler.scheduleTask { whitelist.add(idx) }
+                is ClientboundContainerSetSlotPacket -> {
+                    if (!inCroesus) return@on
+                    val slot = packet.slot
+                    if (slot !in 0..<45) return@on
+                    updateSlotHighlight(slot, packet.item)
                 }
             }
-
-            inCroesus = false
         }
 
         on<PacketSentEvent> { event ->
             val packet = event.packet
             if (packet !is ServerboundContainerClosePacket) return@on
 
-            Scheduler.scheduleTask {
-                blacklist.clear()
-                whitelist.clear()
-            }
+            inCroesus = false
+            blacklist.clear()
+            whitelist.clear()
         }
 
         on<RenderSlotEvent> { event ->
@@ -101,7 +96,25 @@ object CroesusHighlightUnopened : Feature(
     }
 
     override fun onWorldChange(event: WorldChangeEvent) {
+        inCroesus = false
         blacklist.clear()
         whitelist.clear()
+    }
+
+    private fun updateSlotHighlight(slotIndex: Int, itemStack: ItemStack?) {
+        whitelist.remove(slotIndex)
+        blacklist.remove(slotIndex)
+
+        if (itemStack == null || itemStack == ItemStack.EMPTY) return
+        if (itemStack.item != Items.PLAYER_HEAD) return
+        val lore = ItemUtils.lore(itemStack) ?: return
+
+        if (lore.any { it.contains("Opened Chest: ") }) {
+            blacklist.add(slotIndex)
+            return
+        }
+        if (lore.any { it == "No chests opened yet!" }) {
+            whitelist.add(slotIndex)
+        }
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
@@ -25,6 +25,12 @@ object PartyFinderHighlight : Feature(
         "Ignores your own class (if dupe class it wont be red highlight)",
         "Party Finder Highlight Role"
     )
+    private val SETTING_IGNORE_CATA_REQUIREMENT = addSwitch(
+        "ignoreCataRequirement",
+        false,
+        "Ignores the cata level requirement",
+        "Party Finder Highlight Cata Level"
+    )
     private val whitelist = CopyOnWriteArrayList<Int>()
     private val blacklist = CopyOnWriteArrayList<Int>()
 
@@ -42,7 +48,8 @@ object PartyFinderHighlight : Feature(
                 if (
                     it.canJoin == PartyFinderListener.PartyFinderStatus.CAN_JOIN ||
                     it.canJoin == PartyFinderListener.PartyFinderStatus.LOW_ROLE && SETTING_IGNORE_ROLE_LEVEL.get() ||
-                    it.canJoin == PartyFinderListener.PartyFinderStatus.DUPE_CLASS && SETTING_IGNORE_OWN_ROLE.get()
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.DUPE_CLASS && SETTING_IGNORE_OWN_ROLE.get() ||
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.LOW_CATA && SETTING_IGNORE_CATA_REQUIREMENT.get()
                 ) {
                     whitelist.add(it.idx)
                     return@forEach

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
@@ -1,14 +1,11 @@
 package com.github.synnerz.devonian.features.dungeons
 
-import com.github.synnerz.devonian.api.ItemUtils
-import com.github.synnerz.devonian.api.Scheduler
-import com.github.synnerz.devonian.api.ScreenUtils
+import com.github.synnerz.devonian.api.dungeon.PartyFinderListener
 import com.github.synnerz.devonian.api.events.*
 import com.github.synnerz.devonian.config.Categories
 import com.github.synnerz.devonian.features.Feature
-import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
-import net.minecraft.world.item.Items
 import java.awt.Color
+import java.util.concurrent.CopyOnWriteArrayList
 
 object PartyFinderHighlight : Feature(
     "partyFinderHighlight",
@@ -16,109 +13,42 @@ object PartyFinderHighlight : Feature(
     Categories.DUNGEONS,
     subcategory = "QOL"
 ) {
-    private val classLevelRegex = "^ (Healer|Tank|Mage|Berserk|Archer) (\\d+)(?:: [\\d.,]+%)?$".toRegex()
-    private val chatClassSwapRegex = "^You have selected the (Healer|Tank|Mage|Berserk|Archer) Dungeon Class!$".toRegex()
-    private val loreClassRegex = "^ (\\w{1,16}): (Healer|Tank|Mage|Berserk|Archer) \\((\\d+)\\)$".toRegex()
-    private val requirementLowCataRegex = "^Requires Catacombs Level \\d+!$".toRegex()
-    private val requirementLowClassRegex = "^Requires a Class at Level \\d+!$".toRegex()
-    private val requirementTooBadRegex = "^Complete previous floor first!$".toRegex()
-    private val refreshCooldownRegex = "^Please wait a few seconds between refreshing!$".toRegex()
-    private var isOnCd = false
-    private val whitelist = mutableListOf<Int>()
-    private val blacklist = mutableListOf<Int>()
-    private var currentRole: String? = null
-    private var inPF = false
-    private var shouldScan = false
+    private val SETTING_IGNORE_ROLE_LEVEL = addSwitch(
+        "ignoreRoleLevel",
+        false,
+        "Ignores the class level requirement",
+        "Party Finder Highlight Role Level"
+    )
+    private val SETTING_IGNORE_OWN_ROLE = addSwitch(
+        "ignoreOwnRole",
+        false,
+        "Ignores your own class (if dupe class it wont be red highlight)",
+        "Party Finder Highlight Role"
+    )
+    private val whitelist = CopyOnWriteArrayList<Int>()
+    private val blacklist = CopyOnWriteArrayList<Int>()
 
     override fun initialize() {
-        on<TabUpdateEvent> { event ->
-            event.matches(classLevelRegex)?.let {
-                currentRole = it[0]
-                return@on
-            }
-        }
+        PartyFinderListener.initialize()
 
-        on<ChatEvent> { event ->
-            event.matches(chatClassSwapRegex)?.let {
-                currentRole = it[0]
-                return@on
-            }
-            event.matches(refreshCooldownRegex)?.let {
-                isOnCd = true
-                return@on
-            }
-        }
-
-        on<ServerContainerOpen> { event ->
-            inPF = event.string() == "Party Finder"
-            shouldScan = inPF
-            if (!shouldScan && (whitelist.isNotEmpty() || blacklist.isNotEmpty()))
-                Scheduler.scheduleTask {
-                    whitelist.clear()
-                    blacklist.clear()
-                }
-        }
-
-        on<ServerContainerClose> {
-            if (whitelist.isNotEmpty() || blacklist.isNotEmpty())
-                Scheduler.scheduleTask {
-                    whitelist.clear()
-                    blacklist.clear()
-                }
-        }
-
-        on<ClientContainerClose> {
-            if (whitelist.isNotEmpty() || blacklist.isNotEmpty())
-                Scheduler.scheduleTask {
-                    whitelist.clear()
-                    blacklist.clear()
-                }
-        }
-
-        on<ServerContainerSetContent> { event ->
-            if (!shouldScan) return@on
-
-            event.forEach { idx, itemStack ->
-                if (itemStack == null || itemStack.isEmpty || itemStack.item != Items.PLAYER_HEAD) return@forEach
-                if (idx > 36) return@forEach
-
-                val lore = ItemUtils.lore(itemStack) ?: return@forEach
-                scanLore(lore, idx)
-            }
-
-            shouldScan = false
-        }
-
-        on<PacketReceivedEvent> { event ->
-            val packet = event.packet
-            if (packet !is ClientboundContainerSetSlotPacket) return@on
-            if (!inPF || shouldScan) return@on
-            val slot = packet.slot
-            val itemStack = packet.item
-
-            if (blacklist.contains(slot) || whitelist.contains(slot)) {
-                Scheduler.scheduleTask {
-                    blacklist.remove(slot)
-                    whitelist.remove(slot)
-                }
-            }
-            if (itemStack.isEmpty) return@on
-            if (itemStack.item != Items.PLAYER_HEAD) return@on
-
-            val lore = ItemUtils.lore(itemStack) ?: return@on
-            scanLore(lore, slot)
-        }
-
-        on<GuiClickEvent> { event ->
-            if (!inPF) return@on
-            val slot = ScreenUtils.cursorSlot(event.screen) ?: return@on
-            if (slot.containerSlot != 46 || slot.container == minecraft.player?.inventory) return@on
-
-            Scheduler.scheduleServerTask(5) {
-                if (isOnCd) return@scheduleServerTask
+        on<PartyFinderListener.PartyFinderEvent> { event ->
+            if (event.parties.isEmpty()) {
                 blacklist.clear()
                 whitelist.clear()
-                isOnCd = false
+                return@on
+            }
+
+            event.parties.forEach {
+                if (
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.CAN_JOIN ||
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.LOW_ROLE && SETTING_IGNORE_ROLE_LEVEL.get() ||
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.DUPE_CLASS && SETTING_IGNORE_OWN_ROLE.get()
+                ) {
+                    whitelist.add(it.idx)
+                    return@forEach
+                }
+
+                blacklist.add(it.idx)
             }
         }
 
@@ -139,32 +69,5 @@ object PartyFinderHighlight : Feature(
     override fun onWorldChange(event: WorldChangeEvent) {
         blacklist.clear()
         whitelist.clear()
-        isOnCd = false
-    }
-
-    private fun scanLore(lore: List<String>, idx: Int) {
-        val rolesIn = mutableListOf<String>()
-        var canJoin = true
-
-        for (line in lore) {
-            if (
-                requirementLowCataRegex.matches(line) ||
-                requirementLowClassRegex.matches(line) ||
-                requirementTooBadRegex.matches(line)
-            ) {
-                canJoin = false
-                break
-            }
-
-            val match = loreClassRegex.matchEntire(line)?.groupValues?.drop(1) ?: continue
-            rolesIn.add(match[1])
-        }
-
-        if (rolesIn.contains(currentRole)) canJoin = false
-
-        if (canJoin)
-            Scheduler.scheduleTask { whitelist.add(idx) }
-        else
-            Scheduler.scheduleTask { blacklist.add(idx) }
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
@@ -1,15 +1,11 @@
 package com.github.synnerz.devonian.features.dungeons
 
-import com.github.synnerz.devonian.api.ItemUtils
-import com.github.synnerz.devonian.api.Scheduler
-import com.github.synnerz.devonian.api.ScreenUtils
+import com.github.synnerz.devonian.api.dungeon.PartyFinderListener
 import com.github.synnerz.devonian.api.events.*
 import com.github.synnerz.devonian.config.Categories
 import com.github.synnerz.devonian.features.Feature
-import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
-import net.minecraft.world.item.Items
 import java.awt.Color
-import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.CopyOnWriteArrayList
 
 object PartyFinderHighlight : Feature(
     "partyFinderHighlight",
@@ -17,104 +13,49 @@ object PartyFinderHighlight : Feature(
     Categories.DUNGEONS,
     subcategory = "QOL"
 ) {
-    private val classLevelRegex = "^ (Healer|Tank|Mage|Berserk|Archer) (\\d+)(?:: [\\d.,]+%)?$".toRegex()
-    private val chatClassSwapRegex = "^You have selected the (Healer|Tank|Mage|Berserk|Archer) Dungeon Class!$".toRegex()
-    private val loreClassRegex = "^ (\\w{1,16}): (Healer|Tank|Mage|Berserk|Archer) \\((\\d+)\\)$".toRegex()
-    private val requirementLowCataRegex = "^Requires Catacombs Level \\d+!$".toRegex()
-    private val requirementLowClassRegex = "^Requires a Class at Level \\d+!$".toRegex()
-    private val requirementTooBadRegex = "^Complete previous floor first!$".toRegex()
-    private val refreshCooldownRegex = "^Please wait a few seconds between refreshing!$".toRegex()
-    private var isOnCd = false
-    private val whitelist = CopyOnWriteArraySet<Int>()
-    private val blacklist = CopyOnWriteArraySet<Int>()
-    private var currentRole: String? = null
-    private var inPF = false
-    private var shouldScan = false
+    private val SETTING_IGNORE_ROLE_LEVEL = addSwitch(
+        "ignoreRoleLevel",
+        false,
+        "Ignores the class level requirement",
+        "Party Finder Highlight Role Level"
+    )
+    private val SETTING_IGNORE_OWN_ROLE = addSwitch(
+        "ignoreOwnRole",
+        false,
+        "Ignores your own class (if dupe class it wont be red highlight)",
+        "Party Finder Highlight Role"
+    )
+    private val SETTING_IGNORE_CATA_REQUIREMENT = addSwitch(
+        "ignoreCataRequirement",
+        false,
+        "Ignores the cata level requirement",
+        "Party Finder Highlight Cata Level"
+    )
+    private val whitelist = CopyOnWriteArrayList<Int>()
+    private val blacklist = CopyOnWriteArrayList<Int>()
 
     override fun initialize() {
-        on<TabUpdateEvent> { event ->
-            event.matches(classLevelRegex)?.let {
-                currentRole = it[0]
+        PartyFinderListener.initialize()
+
+        on<PartyFinderListener.PartyFinderEvent> { event ->
+            if (event.parties.isEmpty()) {
+                blacklist.clear()
+                whitelist.clear()
                 return@on
             }
-        }
 
-        on<ChatEvent> { event ->
-            event.matches(chatClassSwapRegex)?.let {
-                currentRole = it[0]
-                return@on
-            }
-            event.matches(refreshCooldownRegex)?.let {
-                isOnCd = true
-                return@on
-            }
-        }
+            event.parties.forEach {
+                if (
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.CAN_JOIN ||
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.LOW_ROLE && SETTING_IGNORE_ROLE_LEVEL.get() ||
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.DUPE_CLASS && SETTING_IGNORE_OWN_ROLE.get() ||
+                    it.canJoin == PartyFinderListener.PartyFinderStatus.LOW_CATA && SETTING_IGNORE_CATA_REQUIREMENT.get()
+                ) {
+                    whitelist.add(it.idx)
+                    return@forEach
+                }
 
-        on<ServerContainerOpen> { event ->
-            inPF = event.string() == "Party Finder"
-            shouldScan = inPF
-            if (!shouldScan && (whitelist.isNotEmpty() || blacklist.isNotEmpty())) {
-                whitelist.clear()
-                blacklist.clear()
-            }
-        }
-
-        on<ServerContainerClose> {
-            if (whitelist.isNotEmpty() || blacklist.isNotEmpty()) {
-                whitelist.clear()
-                blacklist.clear()
-            }
-        }
-
-        on<ClientContainerClose> {
-            if (whitelist.isNotEmpty() || blacklist.isNotEmpty()) {
-                whitelist.clear()
-                blacklist.clear()
-            }
-        }
-
-        on<ServerContainerSetContent> { event ->
-            if (!shouldScan) return@on
-
-            event.forEach { idx, itemStack ->
-                if (itemStack == null || itemStack.isEmpty || itemStack.item != Items.PLAYER_HEAD) return@forEach
-                if (idx > 36) return@forEach
-
-                val lore = ItemUtils.lore(itemStack) ?: return@forEach
-                scanLore(lore, idx)
-            }
-
-            shouldScan = false
-        }
-
-        on<PacketReceivedEvent> { event ->
-            val packet = event.packet
-            if (packet !is ClientboundContainerSetSlotPacket) return@on
-            if (!inPF || shouldScan) return@on
-            val slot = packet.slot
-            val itemStack = packet.item
-
-            if (blacklist.contains(slot) || whitelist.contains(slot)) {
-                blacklist.remove(slot)
-                whitelist.remove(slot)
-            }
-            if (itemStack.isEmpty) return@on
-            if (itemStack.item != Items.PLAYER_HEAD) return@on
-
-            val lore = ItemUtils.lore(itemStack) ?: return@on
-            scanLore(lore, slot)
-        }
-
-        on<GuiClickEvent> { event ->
-            if (!inPF) return@on
-            val slot = ScreenUtils.cursorSlot(event.screen) ?: return@on
-            if (slot.containerSlot != 46 || slot.container == minecraft.player?.inventory) return@on
-
-            Scheduler.scheduleServerTask(5) {
-                if (isOnCd) return@scheduleServerTask
-                blacklist.clear()
-                whitelist.clear()
-                isOnCd = false
+                blacklist.add(it.idx)
             }
         }
 
@@ -135,32 +76,5 @@ object PartyFinderHighlight : Feature(
     override fun onWorldChange(event: WorldChangeEvent) {
         blacklist.clear()
         whitelist.clear()
-        isOnCd = false
-    }
-
-    private fun scanLore(lore: List<String>, idx: Int) {
-        val rolesIn = mutableListOf<String>()
-        var canJoin = true
-
-        for (line in lore) {
-            if (
-                requirementLowCataRegex.matches(line) ||
-                requirementLowClassRegex.matches(line) ||
-                requirementTooBadRegex.matches(line)
-            ) {
-                canJoin = false
-                break
-            }
-
-            val match = loreClassRegex.matchEntire(line)?.groupValues?.drop(1) ?: continue
-            rolesIn.add(match[1])
-        }
-
-        if (rolesIn.contains(currentRole)) canJoin = false
-
-        if (canJoin)
-            whitelist.add(idx)
-        else
-            blacklist.add(idx)
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderHighlight.kt
@@ -9,6 +9,7 @@ import com.github.synnerz.devonian.features.Feature
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
 import net.minecraft.world.item.Items
 import java.awt.Color
+import java.util.concurrent.CopyOnWriteArraySet
 
 object PartyFinderHighlight : Feature(
     "partyFinderHighlight",
@@ -24,8 +25,8 @@ object PartyFinderHighlight : Feature(
     private val requirementTooBadRegex = "^Complete previous floor first!$".toRegex()
     private val refreshCooldownRegex = "^Please wait a few seconds between refreshing!$".toRegex()
     private var isOnCd = false
-    private val whitelist = mutableListOf<Int>()
-    private val blacklist = mutableListOf<Int>()
+    private val whitelist = CopyOnWriteArraySet<Int>()
+    private val blacklist = CopyOnWriteArraySet<Int>()
     private var currentRole: String? = null
     private var inPF = false
     private var shouldScan = false
@@ -52,27 +53,24 @@ object PartyFinderHighlight : Feature(
         on<ServerContainerOpen> { event ->
             inPF = event.string() == "Party Finder"
             shouldScan = inPF
-            if (!shouldScan && (whitelist.isNotEmpty() || blacklist.isNotEmpty()))
-                Scheduler.scheduleTask {
-                    whitelist.clear()
-                    blacklist.clear()
-                }
+            if (!shouldScan && (whitelist.isNotEmpty() || blacklist.isNotEmpty())) {
+                whitelist.clear()
+                blacklist.clear()
+            }
         }
 
         on<ServerContainerClose> {
-            if (whitelist.isNotEmpty() || blacklist.isNotEmpty())
-                Scheduler.scheduleTask {
-                    whitelist.clear()
-                    blacklist.clear()
-                }
+            if (whitelist.isNotEmpty() || blacklist.isNotEmpty()) {
+                whitelist.clear()
+                blacklist.clear()
+            }
         }
 
         on<ClientContainerClose> {
-            if (whitelist.isNotEmpty() || blacklist.isNotEmpty())
-                Scheduler.scheduleTask {
-                    whitelist.clear()
-                    blacklist.clear()
-                }
+            if (whitelist.isNotEmpty() || blacklist.isNotEmpty()) {
+                whitelist.clear()
+                blacklist.clear()
+            }
         }
 
         on<ServerContainerSetContent> { event ->
@@ -97,10 +95,8 @@ object PartyFinderHighlight : Feature(
             val itemStack = packet.item
 
             if (blacklist.contains(slot) || whitelist.contains(slot)) {
-                Scheduler.scheduleTask {
-                    blacklist.remove(slot)
-                    whitelist.remove(slot)
-                }
+                blacklist.remove(slot)
+                whitelist.remove(slot)
             }
             if (itemStack.isEmpty) return@on
             if (itemStack.item != Items.PLAYER_HEAD) return@on
@@ -163,8 +159,8 @@ object PartyFinderHighlight : Feature(
         if (rolesIn.contains(currentRole)) canJoin = false
 
         if (canJoin)
-            Scheduler.scheduleTask { whitelist.add(idx) }
+            whitelist.add(idx)
         else
-            Scheduler.scheduleTask { blacklist.add(idx) }
+            blacklist.add(idx)
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderOverview.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PartyFinderOverview.kt
@@ -1,0 +1,147 @@
+package com.github.synnerz.devonian.features.dungeons
+
+import com.github.synnerz.devonian.api.Scheduler
+import com.github.synnerz.devonian.api.WebRequests
+import com.github.synnerz.devonian.api.dungeon.PartyFinderListener
+import com.github.synnerz.devonian.api.events.ServerTickEvent
+import com.github.synnerz.devonian.config.Categories
+import com.github.synnerz.devonian.features.Feature
+import com.github.synnerz.devonian.utils.PersistentJson
+import com.github.synnerz.devonian.utils.StringUtils
+import kotlinx.coroutines.launch
+import net.minecraft.ChatFormatting
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.core.component.DataComponents
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.Style
+import net.minecraft.world.item.component.ItemLore
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+
+object PartyFinderOverview : Feature(
+    "partyFinderOverview",
+    "Customizes the tooltip for party finder parties so they show more information (only parties you can join currently)",
+    Categories.DUNGEONS,
+    subcategory = "QOL"
+) {
+    private const val DUNGEONS_API = "https://dungeons.docilelm.workers.dev/?name="
+    private val SETTING_PB_MODE = addSelection(
+        "pbMode",
+        0,
+        listOf("Both", "S", "S+"),
+        "The pb mode to use whenever displaying personal best time for the current floor. \"Both\" = if S+ does not exist it'll default to S",
+        "Party Finder Overview PB"
+    )
+    private val members = CopyOnWriteArrayList<String>()
+    private val cachedMembers = ConcurrentHashMap<String, DungeonsApiResult>()
+    private val parties = CopyOnWriteArrayList<PartyFinderListener.PartyFinderData>()
+
+    data class UserDungeonsData(
+        val cataXP: Double,
+        val level: Double,
+        val secrets: Int,
+        val averageSecrets: Double,
+        val personal_best_normal: Map<String, Map<String, String>>, // { s: { "floor_1": "1:15" }, s_plus: { "floor_1": "1:15" } }
+        val personal_best_master: Map<String, Map<String, String>>,
+    )
+
+    data class DungeonsApiResult(
+        var timeTaken: Long,
+        val success: Boolean,
+        val status: String,
+        val data: UserDungeonsData
+    )
+
+    override fun initialize() {
+        Scheduler.schedulePool.scheduleWithFixedDelay(::onUpdate, 5L, 5L, TimeUnit.SECONDS)
+
+        on<PartyFinderListener.PartyFinderEvent> { event ->
+            members.clear()
+            parties.clear()
+            if (event.parties.isEmpty()) return@on
+
+            event.parties.forEach {
+                if (
+                    it.canJoin != PartyFinderListener.PartyFinderStatus.CAN_JOIN &&
+                    it.canJoin != PartyFinderListener.PartyFinderStatus.DUPE_CLASS
+                ) return@forEach
+
+                parties.add(it)
+
+                it.members.forEach { m -> members.add(m.name) }
+            }
+        }
+
+        on<ServerTickEvent> { event ->
+            if (parties.isEmpty()) return@on
+
+            // slightly less efficient workaround to avoid re-set of lore data,
+            // although it is still more efficient than doing it inside render tooltip
+            parties.forEach { p ->
+                val screen = (minecraft.screen as? AbstractContainerScreen<*>) ?: return@on
+                val slot = p.idx
+                val itemStack = screen.menu.items.getOrNull(slot) ?: return@forEach
+                val lore = itemStack.get(DataComponents.LORE) ?: return@forEach
+                val newLore = mutableListOf<Component>()
+
+                lore.lines.toList().forEach { l ->
+                    val match = PartyFinderListener.USER_ROLE_REGEX.matchEntire(l.string)?.groupValues?.drop(1)
+                    if (match == null) {
+                        newLore.add(l.copy())
+                        return@forEach
+                    }
+                    val cache = cachedMembers[match[0]]
+                    if (cache == null) {
+                        newLore.add(l.copy())
+                        return@forEach
+                    }
+                    if (l.string.contains("[") && l.string.contains("]")) return@forEach
+                    val personalBestMap = if (p.isMasterMode) cache.data.personal_best_master else cache.data.personal_best_normal
+                    val ( personalBest, type ) = when (SETTING_PB_MODE.get()) {
+                        1 -> personalBestMap["s"]?.get("floor_${p.floor}") to "S"
+                        2 -> personalBestMap["s_plus"]?.get("floor_${p.floor}") to "S+"
+                        else -> (personalBestMap["s_plus"]?.get("floor_${p.floor}")?.let { it to "S+" })
+                            ?: (personalBestMap["s"]?.get("floor_${p.floor}") to "S")
+                    }
+
+                    val mut = l.copy()
+                        .append(Component.literal(" (").withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY)))
+                        .append(Component.literal("${cache.data.level}").withStyle(Style.EMPTY.withColor(ChatFormatting.GOLD)))
+                        .append(Component.literal(") ").withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY)))
+                        .append(Component.literal("[").withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY)))
+                        .append(Component.literal("${StringUtils.addCommas(cache.data.secrets)}/${"%.2f".format(cache.data.averageSecrets)}").withStyle(ChatFormatting.AQUA))
+                        .append(Component.literal("] ").withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY)))
+                    if (personalBest != null) {
+                        mut
+                            .append(Component.literal("[").withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY)))
+                            .append(Component.literal("$type $personalBest").withStyle(Style.EMPTY.withColor(ChatFormatting.GREEN)))
+                            .append(Component.literal("]").withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY)))
+                    }
+
+                    newLore.add(mut)
+                }
+
+                if (newLore.isEmpty()) return@forEach
+
+                itemStack.set(DataComponents.LORE, ItemLore(newLore.toList()))
+            }
+        }
+    }
+
+    private fun onUpdate() {
+        if (members.isEmpty()) return
+
+        WebRequests.ioScope.launch {
+            val username = members.removeFirstOrNull() ?: return@launch
+            val cachedData = cachedMembers[username]
+            if (cachedData != null && System.currentTimeMillis() - cachedData.timeTaken <= (1000 * 60) * 20) return@launch
+
+            val response = WebRequests.get("${DUNGEONS_API}$username")
+            val data = PersistentJson.gson.fromJson(response, DungeonsApiResult::class.java)
+            data.timeTaken = System.currentTimeMillis()
+
+            cachedMembers[username] = data
+        }
+    }
+}

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PositionMessages.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PositionMessages.kt
@@ -8,7 +8,6 @@ import com.github.synnerz.devonian.api.dungeon.Dungeons
 import com.github.synnerz.devonian.api.events.*
 import com.github.synnerz.devonian.config.Categories
 import com.github.synnerz.devonian.features.Feature
-import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket
 import java.awt.Color
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -38,57 +37,68 @@ object PositionMessages : Feature(
         "Removes the highlight around the positional message if you have already sent the message",
         "Position Messages Remove Highlight"
     )
+    private val SETTING_USE_ALL = addSwitch(
+        "useAll",
+        false,
+        "Use all the positional messages not only the current selected class ones",
+        "Position Messages Use All"
+    )
     // TODO: make these customizable
     private val positionList = mapOf(
         'a' to listOf(
-            PosMsg(108, 120, 94, 1.5, "at ss!"),
-            PosMsg(58, 109, 131, 1.5, "at ee2!"),
-            PosMsg(60, 132, 139, 1.5, "at ee2 high!"),
-            PosMsg(69, 109, 121, 0.4999, "at ee2 safe spot!"),
-            PosMsg(67, 109, 121, 0.4999, "at ee2 safe spot!"),
-            PosMsg(48, 109, 121, 0.4999, "at ee2 safe spot!"),
-            PosMsg(46, 109, 121, 0.4999, "at ee2 safe spot!"),
-            PosMsg(54, 65, 76, 7.5, "at mid!"),
+            PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
+            PosMsg(58.0, 109.0, 131.0, 1.5, "at ee2!"),
+            PosMsg(60.5, 132.0, 139.5, 1.5, "at ee2 high!"),
+            PosMsg(69.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
+            PosMsg(67.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
+            PosMsg(48.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
+            PosMsg(46.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
+            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 3.0, null),
         ),
         'b' to listOf(
-            PosMsg(63, 127, 35, 1.5, "at i4!"),
-            PosMsg(54, 65, 76, 7.5, "at mid!"),
+            PosMsg(63.5, 127.0, 35.5, 1.5, "at i4!"),
+            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 3.0, null),
         ),
         'm' to listOf(
-            PosMsg(58, 123, 122, 0.3, "entering core!"),
-            PosMsg(54, 115, 50, 1.5, "at core!"),
-            PosMsg(54, 65, 76, 7.5, "at mid!"),
+            PosMsg(58.5, 123.0, 122.5, 0.3, "entering core!"),
+            PosMsg(54.5, 115.0, 50.5, 1.5, "at core!"),
+            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 3.0, null),
         ),
         't' to listOf(
-            PosMsg(54, 65, 76, 7.5, "at mid!")
+            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 3.0, null),
         ),
         'h' to listOf(
-            PosMsg(108, 120, 94, 1.5, "at ss!"),
-            PosMsg(2, 109, 104, 1.5, "at ee3!"),
-            PosMsg(18, 121, 91, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 92, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 93, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 94, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 95, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 96, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 97, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 98, 0.45, "at ee3 safe spot!"),
-            PosMsg(18, 121, 99, 0.45, "at ee3 safe spot!"),
-            PosMsg(-1, 120, 77, 1.5, "at arrows dev!"),
-            PosMsg(60, 132, 139, 1.5, "at levers dev!"),
-            PosMsg(54, 65, 76, 7.5, "at mid!"),
-            PosMsg(54, 5, 76, 3.0, "at p5!"),
+            PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
+            PosMsg(2.0, 109.0, 104.0, 1.5, "at ee3!"),
+            PosMsg(18.5, 121.0, 91.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 92.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 93.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 94.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 95.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 96.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 97.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 98.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(18.5, 121.0, 99.5, 0.45, "at ee3 safe spot!"),
+            PosMsg(-0.5, 120.0, 77.5, 1.5, "at arrows dev!"),
+            PosMsg(60.5, 132.0, 139.5, 1.5, "at levers dev!"),
+            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
+            PosMsg(54.5, 5.0, 76.5, 3.0, "at p5!"),
+            PosMsg(54.5, 63.7, 114.5, 3.0, null),
         )
     )
     private var currentPos: List<PosMsg>? = null
 
     data class AxisBox(val minx: Double, val miny: Double, val minz: Double, val maxx: Double, val maxy: Double, val maxz: Double)
     data class PosMsg(
-        val x: Int,
-        val y: Int,
-        val z: Int,
+        val x: Double,
+        val y: Double,
+        val z: Double,
         val dist: Double = 1.0,
-        val message: String,
+        val message: String?,
         var sent: Boolean = false,
         val box: AxisBox = AxisBox(
             floor(x - dist),
@@ -106,6 +116,10 @@ object PositionMessages : Feature(
             val playerName = minecraft.player?.name?.string
             val playerData = Dungeons.players[playerName] ?: return@on
             if (playerData.role == DungeonClass.Unknown || playerData.isDead) return@on
+            if (SETTING_USE_ALL.get()) {
+                currentPos = positionList.values.flatten()
+                return@on
+            }
 
             currentPos = positionList[playerData.role.singleLetter]
         }
@@ -113,19 +127,16 @@ object PositionMessages : Feature(
         on<ServerTickEvent> { event ->
             if (!Dungeons.inBoss.value || Dungeons.floor.floorNum != 7) return@on
 
-            val pos = minecraft.player?.position() ?: return@on
+            val pos = minecraft.player ?: return@on
             val msg = currentPos?.find {
-                val dx = it.x - pos.x
-                val dy = it.y - pos.y
-                val dz = it.z - pos.z
-                val rad = dx * dx + dy * dy + dz * dz
-
-                if (rad <= it.dist * it.dist) return@find true
-                false
+                pos.distanceToSqr(it.x, it.y, it.z) <= it.dist
             } ?: return@on
             if (msg.sent) return@on
 
-            Scheduler.scheduleTask { ChatUtils.say("/pc ${msg.message}") }
+            Scheduler.scheduleTask {
+                if (msg.message == null) return@scheduleTask
+                ChatUtils.say("/pc ${msg.message}")
+            }
             msg.sent = true
         }
 
@@ -137,7 +148,7 @@ object PositionMessages : Feature(
                 if (SETTING_REMOVE_AT.get() && it.sent) return@forEach
 
                 Context.Immediate?.renderBox(
-                    it.x.toDouble() - it.dist / 2, it.y.toDouble(), it.z.toDouble() - it.dist / 2,
+                    it.x - it.dist / 2, it.y, it.z - it.dist / 2,
                     it.dist * 2, 0.5,
                     SETTING_RENDER_COLOR.getColor(),
                 )

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PositionMessages.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PositionMessages.kt
@@ -9,6 +9,7 @@ import com.github.synnerz.devonian.api.events.*
 import com.github.synnerz.devonian.config.Categories
 import com.github.synnerz.devonian.features.Feature
 import java.awt.Color
+import java.util.EnumMap
 
 object PositionMessages : Feature(
     "positionMessages",
@@ -42,40 +43,42 @@ object PositionMessages : Feature(
         "Position Messages Use All"
     )
     // TODO: make these customizable
-    private val positionList = mapOf(
-        'a' to listOf(
-            PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
-            PosMsg(58.0, 109.0, 131.0, 1.5, "at ee2!"),
-            PosMsg(60.0, 132.0, 140.0, 1.5, "at ee2 high!"),
-            PosMsg(69.0, 109.0, 122.0, 1.0, "at ee2 safe spot!"),
-            PosMsg(48.0, 109.0, 122.0, 1.0, "at ee2 safe spot!"),
-            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 2.0, null),
-        ),
-        'b' to listOf(
-            PosMsg(63.0, 127.0, 35.0, 1.5, "at i4!"),
-            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 2.0, null),
-        ),
-        'm' to listOf(
-            PosMsg(58.0, 123.0, 122.0, 0.3, "entering core!"),
-            PosMsg(54.0, 115.0, 51.0, 1.5, "at core!"),
-            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 2.0, null),
-        ),
-        't' to listOf(
-            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 2.0, null),
-        ),
-        'h' to listOf(
-            PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
-            PosMsg(2.0, 109.0, 104.0, 1.5, "at ee3!"),
-            PosMsg(18.0, 121.0, 99.0, 3.0, "at ee3 safe spot!"),
-            PosMsg(-1.0, 120.0, 77.0, 1.5, "at arrows dev!"),
-            PosMsg(60.0, 132.0, 140.0, 1.5, "at levers dev!"),
-            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
-            PosMsg(54.5, 5.0, 74.0, 4.0, "at p5!"),
-            PosMsg(54.5, 63.7, 114.5, 2.0, null),
+    private val positionList = EnumMap(
+        mapOf(
+            DungeonClass.Archer to listOf(
+                PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
+                PosMsg(58.0, 109.0, 131.0, 1.5, "at ee2!"),
+                PosMsg(60.0, 132.0, 140.0, 1.5, "at ee2 high!"),
+                PosMsg(69.0, 109.0, 122.0, 1.0, "at ee2 safe spot!"),
+                PosMsg(48.0, 109.0, 122.0, 1.0, "at ee2 safe spot!"),
+                PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+                PosMsg(54.5, 63.7, 114.5, 2.0, null),
+            ),
+            DungeonClass.Berserk to listOf(
+                PosMsg(63.0, 127.0, 35.0, 1.5, "at i4!"),
+                PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+                PosMsg(54.5, 63.7, 114.5, 2.0, null),
+            ),
+            DungeonClass.Mage to listOf(
+                PosMsg(58.0, 123.0, 122.0, 0.3, "entering core!"),
+                PosMsg(54.0, 115.0, 51.0, 1.5, "at core!"),
+                PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+                PosMsg(54.5, 63.7, 114.5, 2.0, null),
+            ),
+            DungeonClass.Tank to listOf(
+                PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+                PosMsg(54.5, 63.7, 114.5, 2.0, null),
+            ),
+            DungeonClass.Healer to listOf(
+                PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
+                PosMsg(2.0, 109.0, 104.0, 1.5, "at ee3!"),
+                PosMsg(18.0, 121.0, 99.0, 3.0, "at ee3 safe spot!"),
+                PosMsg(-1.0, 120.0, 77.0, 1.5, "at arrows dev!"),
+                PosMsg(60.0, 132.0, 140.0, 1.5, "at levers dev!"),
+                PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+                PosMsg(54.5, 5.0, 74.0, 4.0, "at p5!"),
+                PosMsg(54.5, 63.7, 114.5, 2.0, null),
+            ),
         )
     )
     private var currentPos: List<PosMsg>? = null
@@ -100,7 +103,7 @@ object PositionMessages : Feature(
                 return@on
             }
 
-            currentPos = positionList[playerData.role.singleLetter]
+            currentPos = positionList[playerData.role]
         }
 
         on<ServerTickEvent> { event ->

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PositionMessages.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/PositionMessages.kt
@@ -9,8 +9,6 @@ import com.github.synnerz.devonian.api.events.*
 import com.github.synnerz.devonian.config.Categories
 import com.github.synnerz.devonian.features.Feature
 import java.awt.Color
-import kotlin.math.ceil
-import kotlin.math.floor
 
 object PositionMessages : Feature(
     "positionMessages",
@@ -48,66 +46,47 @@ object PositionMessages : Feature(
         'a' to listOf(
             PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
             PosMsg(58.0, 109.0, 131.0, 1.5, "at ee2!"),
-            PosMsg(60.5, 132.0, 139.5, 1.5, "at ee2 high!"),
-            PosMsg(69.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
-            PosMsg(67.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
-            PosMsg(48.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
-            PosMsg(46.5, 109.0, 121.5, 0.4999, "at ee2 safe spot!"),
-            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 3.0, null),
+            PosMsg(60.0, 132.0, 140.0, 1.5, "at ee2 high!"),
+            PosMsg(69.0, 109.0, 122.0, 1.0, "at ee2 safe spot!"),
+            PosMsg(48.0, 109.0, 122.0, 1.0, "at ee2 safe spot!"),
+            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 2.0, null),
         ),
         'b' to listOf(
-            PosMsg(63.5, 127.0, 35.5, 1.5, "at i4!"),
-            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 3.0, null),
+            PosMsg(63.0, 127.0, 35.0, 1.5, "at i4!"),
+            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 2.0, null),
         ),
         'm' to listOf(
-            PosMsg(58.5, 123.0, 122.5, 0.3, "entering core!"),
-            PosMsg(54.5, 115.0, 50.5, 1.5, "at core!"),
-            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 3.0, null),
+            PosMsg(58.0, 123.0, 122.0, 0.3, "entering core!"),
+            PosMsg(54.0, 115.0, 51.0, 1.5, "at core!"),
+            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 2.0, null),
         ),
         't' to listOf(
-            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
-            PosMsg(54.5, 63.7, 114.5, 3.0, null),
+            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+            PosMsg(54.5, 63.7, 114.5, 2.0, null),
         ),
         'h' to listOf(
             PosMsg(108.0, 120.0, 94.0, 1.5, "at ss!"),
             PosMsg(2.0, 109.0, 104.0, 1.5, "at ee3!"),
-            PosMsg(18.5, 121.0, 91.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 92.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 93.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 94.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 95.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 96.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 97.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 98.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(18.5, 121.0, 99.5, 0.45, "at ee3 safe spot!"),
-            PosMsg(-0.5, 120.0, 77.5, 1.5, "at arrows dev!"),
-            PosMsg(60.5, 132.0, 139.5, 1.5, "at levers dev!"),
-            PosMsg(54.5, 65.0, 76.5, 7.5, "at mid!"),
-            PosMsg(54.5, 5.0, 76.5, 3.0, "at p5!"),
-            PosMsg(54.5, 63.7, 114.5, 3.0, null),
+            PosMsg(18.0, 121.0, 99.0, 3.0, "at ee3 safe spot!"),
+            PosMsg(-1.0, 120.0, 77.0, 1.5, "at arrows dev!"),
+            PosMsg(60.0, 132.0, 140.0, 1.5, "at levers dev!"),
+            PosMsg(54.0, 65.0, 76.0, 7.5, "at mid!"),
+            PosMsg(54.5, 5.0, 74.0, 4.0, "at p5!"),
+            PosMsg(54.5, 63.7, 114.5, 2.0, null),
         )
     )
     private var currentPos: List<PosMsg>? = null
 
-    data class AxisBox(val minx: Double, val miny: Double, val minz: Double, val maxx: Double, val maxy: Double, val maxz: Double)
     data class PosMsg(
         val x: Double,
         val y: Double,
         val z: Double,
         val dist: Double = 1.0,
         val message: String?,
-        var sent: Boolean = false,
-        val box: AxisBox = AxisBox(
-            floor(x - dist),
-            floor(y - dist),
-            floor(z - dist),
-            ceil(x + dist),
-            ceil(y + dist),
-            ceil(z + dist)
-        )
+        var sent: Boolean = false
     )
 
     override fun initialize() {
@@ -129,7 +108,7 @@ object PositionMessages : Feature(
 
             val pos = minecraft.player ?: return@on
             val msg = currentPos?.find {
-                pos.distanceToSqr(it.x, it.y, it.z) <= it.dist
+                pos.distanceToSqr(it.x, it.y, it.z) <= (it.dist * it.dist) / 2
             } ?: return@on
             if (msg.sent) return@on
 
@@ -148,8 +127,8 @@ object PositionMessages : Feature(
                 if (SETTING_REMOVE_AT.get() && it.sent) return@forEach
 
                 Context.Immediate?.renderBox(
-                    it.x - it.dist / 2, it.y, it.z - it.dist / 2,
-                    it.dist * 2, 0.5,
+                    it.x, it.y, it.z,
+                    1.0, 0.5,
                     SETTING_RENDER_COLOR.getColor(),
                 )
             }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/ScoreDisplay.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/ScoreDisplay.kt
@@ -69,7 +69,9 @@ object ScoreDisplay : TextHudFeature(
         }
         val m = if (mimic) "&a&l✔" else "&c&l✘"
         val p = if (prince) "&a&l✔" else "&c&l✘"
-        val unfound = if (SETTING_SHOW_UNFOUND.get()) "&7Unfound: &a${Dungeons.totalRoomSecrets.value} " else ""
+        val unfound = if (SETTING_SHOW_UNFOUND.get())
+            "&7Unfound: &a${(Dungeons.totalSecretsRequired.value - Dungeons.totalRoomSecrets.value).coerceAtLeast(0)} "
+            else ""
         if (SETTING_ILLEGALMAP_FORMAT.get()) return listOf(
             "&7Secrets: &b$secrets&7-&e${remainingSecrets}&7-&c$totalSecrets &8| &7Score: $tierColor$score",
             "$unfound&7C: ${if (crypts >= 5) "&a" else "&c"}$crypts &8| &7M: $m &8| &7P: $p"

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/ScoreDisplay.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/ScoreDisplay.kt
@@ -57,6 +57,7 @@ object ScoreDisplay : TextHudFeature(
         secretsRequired: Int,
         totalSecrets: Int,
         remainingSecrets: Int,
+        totalRoomSecrets: Int,
         floor: FloorType
     ): List<String> {
         val tierColor = when {
@@ -70,7 +71,7 @@ object ScoreDisplay : TextHudFeature(
         val m = if (mimic) "&a&l✔" else "&c&l✘"
         val p = if (prince) "&a&l✔" else "&c&l✘"
         val unfound = if (SETTING_SHOW_UNFOUND.get())
-            "&7Unfound: &a${(Dungeons.totalSecretsRequired.value - Dungeons.totalRoomSecrets.value).coerceAtLeast(0)} "
+            "&7Unfound: &a${(totalSecrets - totalRoomSecrets).coerceAtLeast(0)} "
             else ""
         if (SETTING_ILLEGALMAP_FORMAT.get()) return listOf(
             "&7Secrets: &b$secrets&7-&e${remainingSecrets}&7-&c$totalSecrets &8| &7Score: $tierColor$score",
@@ -108,7 +109,7 @@ object ScoreDisplay : TextHudFeature(
         301,
         false, true, 4,
         54, 61, 61,
-        0,
+        0, 0,
         FloorType.M7
     )
 
@@ -126,6 +127,7 @@ object ScoreDisplay : TextHudFeature(
                     Dungeons.totalSecretsRequired.value,
                     Dungeons.totalSecrets.value,
                     Dungeons.remainingMinSecrets.value,
+                    Dungeons.totalRoomSecrets.value,
                     Dungeons.floor
                 )
             )

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/ScoreDisplay.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/ScoreDisplay.kt
@@ -31,6 +31,12 @@ object ScoreDisplay : TextHudFeature(
         "",
         "Show Mimic/Prince State",
     )
+    private val SETTING_SHOW_UNFOUND = addSwitch(
+        "showUnFound",
+        true,
+        "Shows the unfound secrets in the current run",
+        "Score Display Unfound"
+    )
     private val SETTING_FORCE_PAUL = addSwitch(
         "paul",
         false,
@@ -63,9 +69,10 @@ object ScoreDisplay : TextHudFeature(
         }
         val m = if (mimic) "&a&l✔" else "&c&l✘"
         val p = if (prince) "&a&l✔" else "&c&l✘"
+        val unfound = if (SETTING_SHOW_UNFOUND.get()) "&7Unfound: &a${Dungeons.totalRoomSecrets.value} " else ""
         if (SETTING_ILLEGALMAP_FORMAT.get()) return listOf(
             "&7Secrets: &b$secrets&7-&e${remainingSecrets}&7-&c$totalSecrets &8| &7Score: $tierColor$score",
-            "&7Crypts: ${if (crypts >= 5) "&a" else "&c"}$crypts &8| &7M: $m &8| &7P: $p"
+            "$unfound&7C: ${if (crypts >= 5) "&a" else "&c"}$crypts &8| &7M: $m &8| &7P: $p"
         )
         val tier = when {
             score < 100 -> "D"

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/TerminalDisplay.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/TerminalDisplay.kt
@@ -1,0 +1,63 @@
+package com.github.synnerz.devonian.features.dungeons
+
+import com.github.synnerz.devonian.api.dungeon.Stages
+import com.github.synnerz.devonian.api.dungeon.TerminalSection
+import com.github.synnerz.devonian.api.events.RenderOverlayEvent
+import com.github.synnerz.devonian.config.Categories
+import com.github.synnerz.devonian.hud.texthud.TextHudFeature
+import com.github.synnerz.devonian.utils.BasicState
+
+object TerminalDisplay : TextHudFeature(
+    "terminalDisplay",
+    "displays current terminals status (# done, gate, etc)",
+    Categories.DUNGEONS,
+    "catacombs",
+    subcategory = "HUD",
+) {
+    override fun createRequirements(): List<BasicState<Boolean>?> {
+        return super.createRequirements() + listOf(Stages.Terminals.isActiveState)
+    }
+
+    private val SETTING_SIMPLE = addSwitch(
+        "simple",
+        true,
+        "",
+        "Simple Mode",
+    )
+
+    private fun colorFor(n: Int, max: Int): String {
+        if (n == max) return "&a"
+        if (n == 0) return "&c"
+        return "&e"
+    }
+
+    override fun initialize() {
+        on<RenderOverlayEvent> { event ->
+            val cur = Stages.Terminals.activeChild as TerminalSection
+            if (SETTING_SIMPLE.get()) {
+                val color = if (cur.gateDestroyed) "&a" else "&c"
+                setLine("${color}${cur.termsDone + cur.leversDone + (if (cur.deviceDone) 1 else 0)}/${cur.terms + 3}")
+            } else {
+                setLines(
+                    listOf(
+                        "${colorFor(cur.termsDone, cur.terms)}Terms: ${cur.termsDone}/${cur.terms}",
+                        "${colorFor(cur.leversDone, 2)}Levers: ${cur.leversDone}/2",
+                        if (cur.deviceDone) "&aDevice: &l✔" else "&cDevice: &l✘",
+                        if (cur.gateDestroyed) "&aGate: &l✔" else "&cGate: &l✘",
+                    )
+                )
+            }
+            draw(event.ctx)
+        }
+    }
+
+    override fun getEditText(): List<String> {
+        if (SETTING_SIMPLE.get()) return listOf("&c2/7")
+        return listOf(
+            "&eTerms: 3/4",
+            "&aLevers: 2/2",
+            "&aDevice: &l✔",
+            "&cGate: &l✘",
+        )
+    }
+}

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/solvers/CampHelper.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/solvers/CampHelper.kt
@@ -166,7 +166,7 @@ object CampHelper : Feature(
 
                 if (SETTING_SHOW_TIMER.get()) Context.Immediate?.renderString(
                     "%.2f".format(ttl * 0.05),
-                    x + w * 0.5, y - 1.0, z + w * 0.5,
+                    x, y - 1.0, z,
                 )
             }
         }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/solvers/CampHelper.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/solvers/CampHelper.kt
@@ -1,0 +1,311 @@
+package com.github.synnerz.devonian.features.dungeons.solvers
+
+import com.github.synnerz.barrl.Context
+import com.github.synnerz.devonian.Devonian
+import com.github.synnerz.devonian.api.ChatUtils
+import com.github.synnerz.devonian.api.Ping
+import com.github.synnerz.devonian.api.Scheduler
+import com.github.synnerz.devonian.api.dungeon.ComponentPosition
+import com.github.synnerz.devonian.api.dungeon.DungeonScanner
+import com.github.synnerz.devonian.api.dungeon.Stages
+import com.github.synnerz.devonian.api.dungeon.WorldPosition
+import com.github.synnerz.devonian.api.dungeon.mapEnums.RoomTypes
+import com.github.synnerz.devonian.api.events.EntityEquipmentEvent
+import com.github.synnerz.devonian.api.events.EventBus
+import com.github.synnerz.devonian.api.events.PacketReceivedEvent
+import com.github.synnerz.devonian.api.events.RenderWorldEvent
+import com.github.synnerz.devonian.api.events.TickEvent
+import com.github.synnerz.devonian.api.events.WorldChangeEvent
+import com.github.synnerz.devonian.config.Categories
+import com.github.synnerz.devonian.features.Feature
+import com.github.synnerz.devonian.mixin.accessor.ClientboundMoveEntityPacketAccessor
+import com.github.synnerz.devonian.utils.BasicState
+import com.github.synnerz.devonian.utils.math.MathUtils
+import net.minecraft.network.protocol.game.ClientboundMoveEntityPacket
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.entity.decoration.ArmorStand
+import net.minecraft.world.item.Items
+import java.awt.Color
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+object CampHelper : Feature(
+    "campHelper",
+    "",
+    Categories.DUNGEONS,
+    "catacombs",
+    subcategory = "Solvers",
+) {
+    override fun createRequirements(): List<BasicState<Boolean>?> {
+        return super.createRequirements() + listOf(Stages.WatcherClear.isActiveState)
+    }
+
+    private val SETTING_SHOW_TIMER = addSwitch(
+        "showTimer",
+        true,
+        "renders timer under each box",
+        "Camp Show Timer",
+    )
+    private val SETTING_USE_PING = addSwitch(
+        "usePing",
+        true,
+        "attempts to correct timer for ping",
+        "Camp Adjust For Ping",
+    )
+    private val SETTING_WIRE_COLOR = addColorPicker(
+        "wireColor",
+        Color(0, 255, 0).rgb,
+        "",
+        "Camp Wire Color",
+    )
+    private val SETTING_FILL_COLOR = addColorPicker(
+        "fillColor",
+        Color(0, 255, 255).rgb,
+        "",
+        "Camp Fill Color",
+    )
+    private val SETTING_LINE_WIDTH = addSlider(
+        "lineWidth",
+        3.0,
+        0.0, 10.0,
+        "",
+        "Camp Line Width",
+    )
+
+    private var bloodComp: ComponentPosition? = null
+    private val bloodStands = ConcurrentHashMap<Int, UndeadGuesser>()
+
+    private fun addStand(id: Int) {
+        bloodStands.putIfAbsent(id, UndeadGuesser(id))
+    }
+
+    override fun initialize() {
+        on<TickEvent> {
+            if (bloodComp != null) return@on
+            bloodComp = DungeonScanner.rooms.find { it?.type == RoomTypes.BLOOD }?.comps?.getOrNull(0)?.toComponent()
+            if (bloodComp != null) {
+                val w = minecraft.level ?: return@on
+                w.entitiesForRendering().forEach {
+                    if (it !is ArmorStand) return@forEach
+
+                    val pos = WorldPosition(it.x.toInt(), it.z.toInt()).toComponent().toRoom()
+                    if (pos != bloodComp) return@forEach
+
+                    val head = it.getItemBySlot(EquipmentSlot.HEAD) ?: return@forEach
+                    if (head.isEmpty) return@forEach
+                    if (head.item != Items.PLAYER_HEAD) return@forEach
+
+                    addStand(it.id)
+                }
+            }
+        }
+
+        on<EntityEquipmentEvent> { event ->
+            if (bloodComp == null) return@on
+            if (event.type != EntityType.ARMOR_STAND) return@on
+
+            if (event.slots.size != 1) return@on
+            val entry = event.slots.getOrNull(0) ?: return@on
+            if (entry.first != EquipmentSlot.HEAD) return@on
+
+            if (entry.second?.item != Items.PLAYER_HEAD) return@on
+
+            val pos = WorldPosition(event.spawnPos.x.toInt(), event.spawnPos.z.toInt()).toComponent().toRoom()
+            if (pos == bloodComp) addStand(event.entityId)
+        }
+
+        on<PacketReceivedEvent> { event ->
+            val packet = event.packet as? ClientboundMoveEntityPacket ?: return@on
+            val id = (event.packet as? ClientboundMoveEntityPacketAccessor)?.entityId ?: return@on
+
+            bloodStands[id]?.update(
+                packet.xa,
+                packet.ya,
+                packet.za,
+                if (Stages.FirstWatcherSpawn.hasFinished()) 40 else 80,
+            )
+        }
+
+        on<RenderWorldEvent> {
+            val t = System.currentTimeMillis()
+            val st = EventBus.serverTicks()
+            bloodStands.forEach { (_, v) ->
+                if (!v.shouldShow()) return@forEach
+
+                val f = if (v.guessTimeOld == 0L) 1.0 else (t - v.guessTime).toDouble() / (v.guessTime - v.guessTimeOld)
+                val ttl = v.ttl(st)
+
+                if (ttl <= -3) return@forEach
+
+                val x = MathUtils.lerp(f, v.guessXOld, v.guessX)
+                val y = MathUtils.lerp(f, v.guessYOld, v.guessY) + 1.0
+                val z = MathUtils.lerp(f, v.guessZOld, v.guessZ)
+
+                val m = 1.0 - (max(ttl, 0) - (if (SETTING_USE_PING.get()) Ping.getMedianPing() / 50.0 else 0.0)) / v.maxTTL
+                val w = 1.0
+                val h = 2.0
+
+                Context.Immediate?.renderFilledBox(
+                    x - w * m * 0.5,
+                    y + (h - h * m) * 0.5,
+                    z - w * m * 0.5,
+                    w * m, h * m,
+                    SETTING_FILL_COLOR.getColor(),
+                )
+                Context.Immediate?.renderBox(
+                    x - w * 0.5, y, z - w * 0.5,
+                    w, h,
+                    SETTING_WIRE_COLOR.getColor(),
+                    lineWidth = SETTING_LINE_WIDTH.get(),
+                )
+
+                if (SETTING_SHOW_TIMER.get()) Context.Immediate?.renderString(
+                    "%.2f".format(ttl * 0.05),
+                    x + w * 0.5, y - 1.0, z + w * 0.5,
+                )
+            }
+        }
+    }
+
+    override fun onWorldChange(event: WorldChangeEvent) {
+        bloodComp = null
+        bloodStands.clear()
+    }
+}
+
+class UndeadGuesser(val id: Int) {
+    var maxTTL = -1
+
+    var ent: Entity? = null
+    val knownT = mutableListOf<Double>()
+    val knownX = mutableListOf<Double>()
+    val knownY = mutableListOf<Double>()
+    val knownZ = mutableListOf<Double>()
+
+    var dead = false
+
+    var guessX = 0.0
+    var guessY = 0.0
+    var guessZ = 0.0
+    var guessXOld = 0.0
+    var guessYOld = 0.0
+    var guessZOld = 0.0
+    var guessTime = 0L
+    var guessTimeOld = 0L
+
+    var startTick = -1
+    var calcStart = false
+
+    var hasSpawn = false
+
+    fun shouldShow() = hasSpawn && (ent?.isAlive == true) && startTick != -1 && !dead && guessTime > 0L
+
+    fun ttl(st: Int) = if (startTick == -1 || maxTTL == -1) 0 else startTick + maxTTL - st
+
+    fun update(dxRaw: Short, dyRaw: Short, dzRaw: Short, maxTtl: Int) {
+        if (dead) return
+        val tick = EventBus.serverTicks()
+
+        val dx = dxRaw / 4096.0
+        val dy = dyRaw / 4096.0
+        val dz = dzRaw / 4096.0
+
+        Scheduler.scheduleBeforePacket {
+            if (ent == null) ent = Devonian.minecraft.level?.getEntity(id) ?: return@scheduleBeforePacket
+
+            val pos = ent!!.positionCodec.base
+            val x = pos.x
+            val y = pos.y
+            val z = pos.z
+
+            if (!hasSpawn) {
+                hasSpawn = true
+
+                if (
+                    fract(x) != 0.5 ||
+                    fract(z) != 0.5 ||
+                    !spawnY.contains(y)
+                ) calcStart = true
+            }
+
+            if (dxRaw == 0.s && dyRaw == 0.s && dzRaw == 0.s) return@scheduleBeforePacket
+
+            if (maxTTL == -1) maxTTL = maxTtl
+
+            if (calcStart) {
+                calcStart = false
+                for (sy in spawnY) {
+                    val t = (y - sy) / dy
+                    if (t < 0.0) continue
+                    if (!eq(fract(x - t * dx), 0.5)) continue
+                    if (!eq(fract(z - t * dz), 0.5)) continue
+                    startTick = tick - (t * 3).roundToInt()
+                    break
+                }
+                if (startTick == -1) {
+                    dead = true
+                    return@scheduleBeforePacket
+                }
+            }
+
+            if (startTick == -1) startTick = tick - 3
+
+            val t = ttl(tick)
+            if (t < -3) {
+                dead = true
+                return@scheduleBeforePacket
+            }
+            knownT.add(tick.toDouble())
+            knownX.add(x + dx)
+            knownY.add(y + dy)
+            knownZ.add(z + dz)
+
+            if (knownT.size < 2) return@scheduleBeforePacket
+
+            // val fit = MathUtils.fitLine3D(knownX, knownY, knownZ)
+            val linX = MathUtils.linReg(knownT, knownX) ?: return@scheduleBeforePacket
+            val linY = MathUtils.linReg(knownT, knownY) ?: return@scheduleBeforePacket
+            val linZ = MathUtils.linReg(knownT, knownZ) ?: return@scheduleBeforePacket
+
+            val x0 = linX.b * t + x + dx
+            val y0 = linY.b * t + y + dy
+            val z0 = linZ.b * t + z + dz
+            // val x1 = fit[0][0]
+            // val y1 = fit[1][0]
+            // val z1 = fit[2][0]
+            // val vx = fit[0][1]
+            // val vy = fit[1][1]
+            // val vz = fit[2][1]
+
+            // val u = -((x1 - x0) * vx + (y1 - y0) * vy + (z1 - z0) * vz) / (vx * vx + vy * vy + vz * vz)
+
+            // val gx = x1 + vx * u
+            // val gy = y1 + vy * u
+            // val gz = z1 + vz * u
+
+            guessXOld = guessX
+            guessYOld = guessY
+            guessZOld = guessZ
+            guessTimeOld = guessTime
+            guessX = x0
+            guessY = y0
+            guessZ = z0
+            guessTime = System.currentTimeMillis()
+        }
+    }
+
+    companion object {
+        private val spawnY = listOf(71.75, 75.75, 79.75)
+
+        private fun eq(a: Double, b: Double) = abs(a - b) < 1e-6
+        private fun fract(v: Double) = v - floor(v)
+    }
+}
+
+private val Int.s
+    get() = this.toShort()

--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/solvers/TerminalSolvers.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/solvers/TerminalSolvers.kt
@@ -2,21 +2,24 @@ package com.github.synnerz.devonian.features.dungeons.solvers
 
 import com.github.synnerz.devonian.api.ScreenUtils
 import com.github.synnerz.devonian.api.dungeon.Stages
-import com.github.synnerz.devonian.api.events.GuiClickEvent
-import com.github.synnerz.devonian.api.events.GuiCloseEvent
-import com.github.synnerz.devonian.api.events.GuiOpenEvent
-import com.github.synnerz.devonian.api.events.RenderSlotEvent
-import com.github.synnerz.devonian.api.events.TickEvent
+import com.github.synnerz.devonian.api.events.*
 import com.github.synnerz.devonian.config.Categories
 import com.github.synnerz.devonian.features.Feature
-import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.SETTING_CANCEL_WRONG_CLICKS
 import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.SETTING_HIDE_DONE
+import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.SETTING_HIDE_ITEMS
+import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.SETTING_RED_GREEN_DISABLE_RENDER
 import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.SETTING_RENDER_NUMBERS
+import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.SETTING_RUBIX_FORCE_POSITIVE
 import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.TerminalSlot
 import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.color
 import com.github.synnerz.devonian.features.dungeons.solvers.TerminalSolvers.minecraft
 import com.github.synnerz.devonian.utils.BasicState
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.core.component.DataComponents
+import net.minecraft.network.chat.Component
+import net.minecraft.sounds.SoundEvents
+import net.minecraft.sounds.SoundSource
+import net.minecraft.world.inventory.Slot
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import kotlin.math.abs
@@ -38,55 +41,85 @@ object TerminalSolvers : Feature(
         "disableTooltip",
         true,
         "Disables the tooltip whenever inside a terminal",
-        "Disable Terminal Tooltip"
+        "Disable Terminal Tooltip",
     )
     private val SETTING_CORRECT_COLOR = addColorPicker(
         "correctColor",
         0xFF4F8F2F.toInt(),
         "The correct color for terminal solver",
-        "Terminal Solver Correct Color"
+        "Terminal Solver Correct Color",
     )
     private val SETTING_SECOND_CORRECT_COLOR = addColorPicker(
         "secondCorrectColor",
         0xFFB5A12E.toInt(),
         "The second correct color for terminal solver",
-        "Terminal Solver Second Correct Color"
+        "Terminal Solver Second Correct Color",
     )
     private val SETTING_THIRD_CORRECT_COLOR = addColorPicker(
         "thirdCorrectColor",
         0xFFB86A2E.toInt(),
         "The third correct color for terminal solver",
-        "Terminal Solver Third Correct Color"
+        "Terminal Solver Third Correct Color",
     )
     private val SETTING_OTHER_CORRECT_COLOR = addColorPicker(
         "otherColor",
         0xFF8F2E2E.toInt(),
         "The other color for terminal solver",
-        "Terminal Solver Other Color"
+        "Terminal Solver Other Color",
     )
-    val SETTING_CANCEL_WRONG_CLICKS = addSwitch(
+    private val SETTING_CANCEL_WRONG_CLICKS = addSwitch(
         "cancelWrongClicks",
         true,
-        "Cancels the wrong clicks inside of Color and StartsWith terminals",
-        "Terminal Solver Cancel Clicks"
+        "Cancels the wrong clicks inside of terminals",
+        "Terminal Solver Cancel Clicks",
     )
+    // private val SETTING_CANCEL_LAG = addSwitch(
+    //     "cancelLag",
+    //     false,
+    //     "Cancels clicks that would've failed due to wrong window id",
+    //     "Terminal Solver Cancel Lag Clicks"
+    // )
     val SETTING_HIDE_DONE = addSwitch(
         "hideDone",
         true,
         "Hides the already clicked slot items or the ones that are not a solution",
-        "Terminal Solver Hide Complete"
+        "Terminal Solver Hide Complete",
     )
+    val SETTING_HIDE_ITEMS = addSwitch(
+        "hideItems",
+        true,
+        "Hides all items in the 'Starts With'/'Select All' terminals",
+        "Terminal Solver Hide Items",
+    )
+    val SETTING_RED_GREEN_DISABLE_RENDER = addSwitch(
+        "redGreen",
+        false,
+        "toggle to specifically disable custom renderer for red/green solver",
+        "Correct All Terminal Vanilla Renderer",
+    )
+
     // make render name for numbers
     val SETTING_RENDER_NUMBERS = addSwitch(
         "renderNumbers",
         true,
         "Whether to render the numbers from Numbers terminal in the slots or not",
-        "Terminal Solver Render Numbers"
+        "Terminal Solver Render Numbers",
     )
-    private var currentSolver: TerminalData? = null
+    val SETTING_RUBIX_FORCE_POSITIVE = addSwitch(
+        "rubixPositive",
+        false,
+        "effectively always shows the clicks required as positive, doesn't affect selecting fastest solution",
+        "Rubix Show Left Click Count",
+    )
 
-    data class TerminalSlot(val slot: Int, val itemStack: ItemStack, var blacklisted: Boolean = false)
-    data class RubixSlot(val slot: Int, val itemStack: ItemStack, var blacklisted: Boolean = false, var count: Int = 0)
+    private var currentSolver: TerminalData? = null
+    // private var lastClickWindowId = 0
+
+    private val PREVENTED_SOUND = SoundEvents.NOTE_BLOCK_BASS
+    // private val LAG_SOUND = SoundEvents.NOTE_BLOCK_BASEDRUM
+
+    data class TerminalSlot(val slot: Int, val itemStack: ItemStack)
+    data class RubixSlot(val slot: Int, val itemStack: ItemStack, val color: Int, val clicks: Int = 0)
 
     override fun initialize() {
         on<GuiOpenEvent> { event ->
@@ -106,8 +139,40 @@ object TerminalSolvers : Feature(
             currentSolver?.onRenderSlot(event)
         }
 
+        on<PostRenderSlotsEvent> { event ->
+            currentSolver?.onAfterRender(event)
+        }
+
         on<GuiClickEvent> { event ->
-            currentSolver?.onClick(event)
+            val slot = ScreenUtils.cursorSlot(event.screen) ?: return@on
+            if (SETTING_CANCEL_WRONG_CLICKS.get() && currentSolver?.cancelClick(slot) == true) {
+                event.cancel()
+                minecraft.level?.playPlayerSound(
+                    PREVENTED_SOUND.value(),
+                    SoundSource.MASTER,
+                    1f, 0.5f,
+                )
+                return@on
+            }
+
+            // TODO: only cancel if last click was correct
+            /*
+            if (!SETTING_CANCEL_LAG.get()) return@on
+            val id = minecraft.player?.containerMenu?.containerId ?: return@on
+            if (currentSolver?.changesWindow != true) return@on
+
+            if (id != lastClickWindowId) {
+                lastClickWindowId = id
+                return@on
+            }
+
+            event.cancel()
+            minecraft.level?.playPlayerSound(
+                LAG_SOUND.value(),
+                SoundSource.MASTER,
+                1f, 0.5f,
+            )
+            */
         }
     }
 
@@ -123,17 +188,22 @@ object TerminalSolvers : Feature(
     }
 }
 
-// TODO: clean this mess up
 interface ITerminalSolver {
+    val changesWindow: Boolean
+
     fun onTick()
 
-    fun onRenderSlot(event: RenderSlotEvent)
+    fun onRenderSlot(event: RenderSlotEvent) {}
 
-    fun onClick(event: GuiClickEvent) {}
+    fun onAfterRender(event: PostRenderSlotsEvent) {}
+
+    fun cancelClick(slot: Slot): Boolean
 }
 
 enum class TerminalData(val title: Regex) : ITerminalSolver {
     NUMBERS("Click in order!".toRegex()) {
+        override val changesWindow: Boolean = true
+
         private var correctSlots = mutableListOf<TerminalSlot>()
 
         override fun onTick() {
@@ -142,9 +212,8 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
 
             correctSlots.clear()
 
-            for (idx in 0..items.lastIndex) {
-                val item = items[idx]
-                if (item.item != Items.RED_STAINED_GLASS_PANE) continue
+            items.forEachIndexed { idx, item ->
+                if (item.item != Items.RED_STAINED_GLASS_PANE) return@forEachIndexed
                 correctSlots.add(TerminalSlot(idx, item))
             }
 
@@ -160,17 +229,24 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
                 return
             }
             val data = correctSlots[idx]
-            if (data.blacklisted) return
 
             event.ctx.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, color(idx))
             if (SETTING_RENDER_NUMBERS.get())
-                event.ctx.drawString(minecraft.font, "${data.itemStack.count}", slot.x + 4, slot.y + 4, -1)
+                event.ctx.drawCenteredString(
+                    minecraft.font,
+                    "${data.itemStack.count}",
+                    slot.x + 8, slot.y + 4, -1
+                )
             event.cancel()
+        }
+
+        override fun cancelClick(slot: Slot): Boolean {
+            return !correctSlots.any { it.slot == slot.containerSlot }
         }
     },
     COLORS("^Select all the (.*?) items!$".toRegex()) {
-        // TODO: colors and startswith don't remove the items when clicked because hypixel is very funny
-        //  and doesn't enchant them as 1.8 version does
+        override val changesWindow: Boolean = true
+
         private val correctSlots = mutableListOf<TerminalSlot>()
         private val fixedColorItems = mapOf(
             "light gray" to "silver",
@@ -191,15 +267,14 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
 
             correctSlots.clear()
 
-            for (idx in 0..items.lastIndex) {
-                val item = items.getOrNull(idx) ?: continue
-                if (item.isEnchanted) continue
+            items.forEachIndexed { idx, item ->
+                if (item.get(DataComponents.ENCHANTMENT_GLINT_OVERRIDE) == true) return@forEachIndexed
                 var name = item.customName?.string ?: item.itemName.string
                 for (fixed in fixedColorItems) {
-                    if (name.lowercase().startsWith(fixed.key))
+                    if (name.startsWith(fixed.key, ignoreCase = true))
                         name = fixed.value
                 }
-                if (!name.lowercase().startsWith(toFind.lowercase())) continue
+                if (!name.startsWith(toFind, ignoreCase = true)) return@forEachIndexed
 
                 correctSlots.add(TerminalSlot(idx, item))
             }
@@ -208,30 +283,23 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
         override fun onRenderSlot(event: RenderSlotEvent) {
             val slot = event.slot
             if (slot.container == minecraft.player?.inventory) return
-            if (slot.item.isEnchanted) return
             val idx = correctSlots.indexOfFirst { it.slot == event.slot.containerSlot }
             if (idx == -1) {
                 if (SETTING_HIDE_DONE.get()) event.cancel()
                 return
             }
-            val data = correctSlots[idx]
-            if (data.itemStack.isEnchanted) data.blacklisted = true
-            if (data.blacklisted) return
 
             event.ctx.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, color(0))
-            event.cancel()
+            if (SETTING_HIDE_ITEMS.get()) event.cancel()
         }
 
-        override fun onClick(event: GuiClickEvent) {
-            if (!SETTING_CANCEL_WRONG_CLICKS.get()) return
-            val slot = ScreenUtils.cursorSlot(event.screen) ?: return
-            val idx = correctSlots.indexOfFirst { it.slot == slot.containerSlot }
-            if (idx != -1) return
-
-            event.cancel()
+        override fun cancelClick(slot: Slot): Boolean {
+            return !correctSlots.any { it.slot == slot.containerSlot }
         }
     },
     STARTS_WITH("^What starts with: '(.*?)'\\?$".toRegex()) {
+        override val changesWindow: Boolean = true
+
         private val correctSlots = mutableListOf<TerminalSlot>()
 
         override fun onTick() {
@@ -241,11 +309,11 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
 
             correctSlots.clear()
 
-            for (idx in 0..items.lastIndex) {
-                val item = items.getOrNull(idx) ?: continue
-                if (item.isEnchanted) continue
+            items.forEachIndexed { idx, item ->
+                if (item.get(DataComponents.ENCHANTMENT_GLINT_OVERRIDE) == true) return@forEachIndexed
+
                 val name = item.customName?.string ?: item.itemName.string
-                if (!name.lowercase().startsWith(toFind.lowercase())) continue
+                if (!name.startsWith(toFind, ignoreCase = true)) return@forEachIndexed
 
                 correctSlots.add(TerminalSlot(idx, item))
             }
@@ -254,31 +322,27 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
         override fun onRenderSlot(event: RenderSlotEvent) {
             val slot = event.slot
             if (slot.container == minecraft.player?.inventory) return
-            if (slot.item.isEnchanted) return
+
             val idx = correctSlots.indexOfFirst { it.slot == event.slot.containerSlot }
             if (idx == -1) {
                 if (SETTING_HIDE_DONE.get()) event.cancel()
                 return
             }
-            val data = correctSlots[idx]
-            if (data.itemStack.isEnchanted) data.blacklisted = true
-            if (data.blacklisted) return
 
             event.ctx.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, color(0))
-            event.cancel()
+            if (SETTING_HIDE_ITEMS.get()) event.cancel()
         }
 
-        override fun onClick(event: GuiClickEvent) {
-            if (!SETTING_CANCEL_WRONG_CLICKS.get()) return
-            val slot = ScreenUtils.cursorSlot(event.screen) ?: return
-            val idx = correctSlots.indexOfFirst { it.slot == slot.containerSlot }
-            if (idx != -1) return
-
-            event.cancel()
+        override fun cancelClick(slot: Slot): Boolean {
+            return !correctSlots.any { it.slot == slot.containerSlot }
         }
     },
     RUBIX("^Change all to same color!$".toRegex()) {
+        override val changesWindow: Boolean = true
+
         private val rubixIndices = listOf(12, 13, 14, 21, 22, 23, 30, 31, 32)
+
+        // left click = ++, right click = --
         private val rubixOrder = listOf(
             Items.ORANGE_STAINED_GLASS_PANE,
             Items.YELLOW_STAINED_GLASS_PANE,
@@ -286,63 +350,77 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
             Items.BLUE_STAINED_GLASS_PANE,
             Items.RED_STAINED_GLASS_PANE,
         )
-        private var correctSlots = mutableListOf<TerminalSolvers.RubixSlot>()
+        private var correctSlots = listOf<TerminalSolvers.RubixSlot>()
+        private val strings = arrayOf(
+            Component.literal("§e-2"),
+            Component.literal("§a-1"),
+            null,
+            Component.literal("§a1"),
+            Component.literal("§e2"),
+            Component.literal("§e3"),
+            Component.literal("§c4"),
+        )
 
         override fun onTick() {
             val screen = minecraft.screen ?: return
             val items = (screen as AbstractContainerScreen<*>).menu.items
             val slotsIn = mutableListOf<TerminalSolvers.RubixSlot>()
 
-            for (idx in rubixIndices) {
-                val item = items.getOrNull(idx) ?: continue
-                if (!rubixOrder.any { it == item.item }) continue
-                slotsIn.add(TerminalSolvers.RubixSlot(idx, item))
+            rubixIndices.forEach { idx ->
+                val item = items.getOrNull(idx) ?: return@forEach
+                val color = rubixOrder.indexOf(item.item)
+                if (color < 0) return@forEach
+                slotsIn.add(TerminalSolvers.RubixSlot(idx, item, color))
             }
 
-            correctSlots.clear()
-
-            var leastClicks = -1
-
-            for (jdx in 0..rubixOrder.lastIndex) {
+            var best = 19
+            for (target in rubixOrder.indices) {
                 var clicks = 0
-                val leftClicks = mutableListOf<TerminalSolvers.RubixSlot>()
-
-                for (slot in slotsIn) {
-                    val idx = rubixOrder.indexOfFirst { it == slot.itemStack.item }
-                    if (idx == -1) continue
-                    val distance =
-                        if (idx < jdx)
-                            jdx - idx
-                        else
-                            jdx + rubixOrder.size - idx
-
-                    clicks += if (distance > 2) abs(distance - 5) else distance
-
-                    slot.count = if (distance > 2) distance - 5 else distance
-                    leftClicks.add(slot)
+                val slots = slotsIn.filter {
+                    var dist = abs(target - it.color)
+                    if (dist >= 3) dist = 5 - dist
+                    clicks += dist
+                    dist > 0
                 }
 
-                if (leastClicks == -1 || clicks < leastClicks) {
-                    leastClicks = clicks
-                    correctSlots = leftClicks
+                if (clicks < best) {
+                    best = clicks
+                    correctSlots = slots.map {
+                        var lc = target - it.color
+                        if (lc < 0) lc += 5
+                        TerminalSolvers.RubixSlot(it.slot, it.itemStack, it.color, lc)
+                    }
                 }
             }
         }
 
-        override fun onRenderSlot(event: RenderSlotEvent) {
-            val slot = event.slot
-            if (slot.container == minecraft.player?.inventory) return
-            if (slot.item.isEnchanted) return
-            val idx = correctSlots.indexOfFirst { it.slot == event.slot.containerSlot }
-            if (idx == -1) return
-            val data = correctSlots[idx]
-            if (data.blacklisted) return
-            if (data.count == 0) return
+        override fun onAfterRender(event: PostRenderSlotsEvent) {
+            event.container.menu.slots.forEach { slot ->
+                if (slot.container == minecraft.player?.inventory) return
 
-            event.ctx.drawString(minecraft.font, "${data.count}", slot.x + 4, slot.y + 5, -1)
+                val data = correctSlots.find { it.slot == slot.containerSlot } ?: return
+
+                val num = if (!SETTING_RUBIX_FORCE_POSITIVE.get() && data.clicks >= 3) data.clicks - 5
+                else data.clicks
+                val str = strings.getOrNull(num + 2) ?: return
+
+                event.ctx.drawCenteredString(minecraft.font, str, slot.x + 8, slot.y + 4, -1)
+            }
+        }
+
+        override fun cancelClick(slot: Slot): Boolean {
+            return false
         }
     },
     RED_GREEN("^Correct all the panes!$".toRegex()) {
+        override val changesWindow: Boolean = true
+
+        private val paneSlots = mutableListOf(
+            11, 12, 13, 14, 15,
+            20, 21, 22, 23, 24,
+            29, 30, 31, 32, 33,
+        )
+
         private val correctSlots = mutableListOf<TerminalSlot>()
 
         override fun onTick() {
@@ -351,27 +429,30 @@ enum class TerminalData(val title: Regex) : ITerminalSolver {
 
             correctSlots.clear()
 
-            for (idx in 0..items.lastIndex) {
-                val item = items[idx]
-                if (item.item != Items.RED_STAINED_GLASS_PANE) continue
+            paneSlots.forEach { idx ->
+                val item = items.getOrNull(idx) ?: return@forEach
+                if (item.item != Items.RED_STAINED_GLASS_PANE) return@forEach
                 correctSlots.add(TerminalSlot(idx, item))
             }
         }
 
         override fun onRenderSlot(event: RenderSlotEvent) {
+            if (SETTING_RED_GREEN_DISABLE_RENDER.get()) return
             val slot = event.slot
             if (slot.container == minecraft.player?.inventory) return
-            if (slot.item.isEnchanted) return
+
             val idx = correctSlots.indexOfFirst { it.slot == event.slot.containerSlot }
             if (idx == -1) {
                 if (SETTING_HIDE_DONE.get()) event.cancel()
                 return
             }
-            val data = correctSlots[idx]
-            if (data.blacklisted) return
 
             event.ctx.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, color(0))
             event.cancel()
+        }
+
+        override fun cancelClick(slot: Slot): Boolean {
+            return false
         }
     };
 

--- a/src/main/kotlin/com/github/synnerz/devonian/features/inventory/ItemRarityBackground.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/inventory/ItemRarityBackground.kt
@@ -41,6 +41,12 @@ object ItemRarityBackground : Feature(
         "",
         "Rarity Render Line Width"
     )
+    private val SETTING_RENDER_HOTBAR = addSwitch(
+        "renderHotbar",
+        true,
+        "Whether to also render the highlight in the hotbar",
+        "Rarity Render Hotbar"
+    )
     private val rarities = listOf(
         "COMMON" to TextColor.fromLegacyFormat(ChatFormatting.WHITE)!!.value,
         "UNCOMMON" to TextColor.fromLegacyFormat(ChatFormatting.GREEN)!!.value,
@@ -114,6 +120,7 @@ object ItemRarityBackground : Feature(
         }.prio = 0
 
         on<RenderHotbarSlotEvent> { event ->
+            if (!SETTING_RENDER_HOTBAR.get()) return@on
             render(event.x, event.y, event.item, event.ctx)
         }.prio = 0
     }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/inventory/NoCursorReset.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/inventory/NoCursorReset.kt
@@ -23,6 +23,7 @@ object NoCursorReset : Feature(
             }
             if (lastScreen != null && screen != null && lastScreen != screen) {
                 resetCursor.value = false
+                lastScreen = screen
                 return@on
             }
             if (lastScreen != null && screen == null) {

--- a/src/main/kotlin/com/github/synnerz/devonian/features/misc/HighlightSellableItems.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/misc/HighlightSellableItems.kt
@@ -21,7 +21,7 @@ object HighlightSellableItems : Feature(
         "Sellable Highlight Color"
     )
     // yoink from skytils <https://github.com/Skytils/SkytilsMod/blob/618bc6d5c03fb026ebbd27ed45484d9fc698138a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt#L222-L232>
-    private val itemNames = listOf(
+    private val itemNames = setOf(
         "Defuse Kit",
         "Lever",
         "Torch",

--- a/src/main/kotlin/com/github/synnerz/devonian/features/misc/HighlightSellableItems.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/misc/HighlightSellableItems.kt
@@ -1,12 +1,12 @@
 package com.github.synnerz.devonian.features.misc
 
 import com.github.synnerz.devonian.api.ItemUtils
-import com.github.synnerz.devonian.api.Scheduler
 import com.github.synnerz.devonian.api.events.*
 import com.github.synnerz.devonian.features.Feature
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
+import net.minecraft.world.item.ItemStack
 import java.awt.Color
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CopyOnWriteArraySet
 import kotlin.jvm.optionals.getOrNull
 
 object HighlightSellableItems : Feature(
@@ -39,7 +39,7 @@ object HighlightSellableItems : Feature(
     )
     private var inSellable = false
     private var scan = false
-    private val slotsToHighlight = CopyOnWriteArrayList<Int>()
+    private val slotsToHighlight = CopyOnWriteArraySet<Int>()
 
     override fun initialize() {
         on<ServerContainerOpen> { event ->
@@ -51,13 +51,13 @@ object HighlightSellableItems : Feature(
         on<ServerContainerClose> {
             inSellable = false
             scan = false
-            Scheduler.scheduleTask { slotsToHighlight.clear() }
+            slotsToHighlight.clear()
         }
 
         on<ClientContainerClose> {
             inSellable = false
             scan = false
-            Scheduler.scheduleTask { slotsToHighlight.clear() }
+            slotsToHighlight.clear()
         }
 
         on<ServerContainerSetContent> { event ->
@@ -67,23 +67,7 @@ object HighlightSellableItems : Feature(
                 if (idx < 54) return@forEach
                 if (itemStack == null || itemStack.isEmpty) return@forEach
 
-                val itemName = itemStack.customName?.string
-                if (itemName != null) {
-                    if (itemNames.contains(itemName.replace(" x\\d+".toRegex(), ""))) {
-                        Scheduler.scheduleTask { slotsToHighlight.add(idx) }
-                        return@forEach
-                    }
-                }
-
-                val extraAttributes = ItemUtils.extraAttributes(itemStack) ?: return@forEach
-                if (extraAttributes.getString("id").getOrNull() == "ICE_SPRAY_WAND") return@forEach
-
-                val baseStat = extraAttributes.getInt("baseStatBoostPercentage")
-
-                if (!baseStat.isPresent || baseStat.get() == 50) return@forEach
-                if (extraAttributes.getInt("upgrade_level").isPresent) return@forEach
-
-                Scheduler.scheduleTask { slotsToHighlight.add(idx) }
+                if (shouldHighlight(itemStack)) slotsToHighlight.add(idx)
             }
 
             scan = false
@@ -92,13 +76,13 @@ object HighlightSellableItems : Feature(
         on<PacketReceivedEvent> { event ->
             val packet = event.packet
             if (packet !is ClientboundContainerSetSlotPacket) return@on
+            if (!inSellable) return@on
             val slot = packet.slot
             val itemStack = packet.item
 
-            if (!slotsToHighlight.contains(slot)) return@on
-            if (!itemStack.isEmpty) return@on
-
-            Scheduler.scheduleTask { slotsToHighlight.remove(slot) }
+            if (slot < 54) return@on
+            slotsToHighlight.remove(slot)
+            if (shouldHighlight(itemStack)) slotsToHighlight.add(slot)
         }
 
         on<RenderSlotEvent> { event ->
@@ -116,5 +100,22 @@ object HighlightSellableItems : Feature(
         inSellable = false
         scan = false
         slotsToHighlight.clear()
+    }
+
+    private fun shouldHighlight(itemStack: ItemStack): Boolean {
+        if (itemStack.isEmpty) return false
+
+        val itemName = itemStack.customName?.string
+        if (itemName != null && itemNames.contains(itemName.replace(" x\\d+".toRegex(), "")))
+            return true
+
+        val extraAttributes = ItemUtils.extraAttributes(itemStack) ?: return false
+        if (extraAttributes.getString("id").getOrNull() == "ICE_SPRAY_WAND") return false
+
+        val baseStat = extraAttributes.getInt("baseStatBoostPercentage")
+        if (!baseStat.isPresent || baseStat.get() == 50) return false
+        if (extraAttributes.getInt("upgrade_level").isPresent) return false
+
+        return true
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/features/misc/Misc.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/misc/Misc.kt
@@ -68,3 +68,4 @@ object CustomSidebarColor : Feature("customSideBarColor", "Sets the color for sc
 object NametagShadow : Feature("nametagShadow", "Enables shadows on name tags", subcategory = "Tweaks")
 object RemoveGlowEffect : Feature("removeGlowEffect", "Removes the glowing effect of every entity", subcategory = "Hiders")
 object SidebarTextShadow : Feature("sidebarTextShadow", "Adds shadows to the text that is rendered in the sidebar", subcategory = "Tweaks")
+object AutoSprint : Feature("autoSprint", "Automatically sets the sprint key to true whenever you are walking", subcategory = "Tweaks")

--- a/src/main/kotlin/com/github/synnerz/devonian/features/misc/ShowSelectedPet.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/misc/ShowSelectedPet.kt
@@ -8,6 +8,7 @@ import com.github.synnerz.devonian.api.events.WorldChangeEvent
 import com.github.synnerz.devonian.features.Feature
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket
 import net.minecraft.world.item.ItemStack
@@ -26,43 +27,56 @@ object ShowSelectedPet : Feature(
         "Selected Pet Color"
     )
     private val petsMenuRegex = "^Pets(?: \\(\\d+/\\d+\\))? ?\$".toRegex()
+    private const val SELECTED_PET_LORE = "Click to despawn!"
     private var inPets = false
     private var currentPetSlot = -1
 
     override fun initialize() {
         on<PacketReceivedEvent> { event ->
             val packet = event.packet
-            if (packet is ClientboundOpenScreenPacket) {
-                val title = packet.title.string
-                inPets = petsMenuRegex.matches(title)
-                currentPetSlot = -1
-                return@on
-            }
+            when (packet) {
+                is ClientboundOpenScreenPacket -> {
+                    val title = packet.title.string
+                    inPets = petsMenuRegex.matches(title)
+                    currentPetSlot = -1
+                    return@on
+                }
 
-            if (packet is ClientboundContainerClosePacket) {
-                inPets = false
-                currentPetSlot = -1
-                return@on
-            }
+                is ClientboundContainerClosePacket -> {
+                    inPets = false
+                    currentPetSlot = -1
+                    return@on
+                }
 
-            if (packet !is ClientboundContainerSetContentPacket) return@on
+                is ClientboundContainerSetContentPacket -> {
+                    val items = packet.items
+                    val possiblyForge = items.getOrNull(10)
+                    if (possiblyForge != null && ItemUtils.skyblockId(possiblyForge) == "BEJEWELED_COLLAR") {
+                        inPets = false
+                        currentPetSlot = -1
+                        return@on
+                    }
+                    if (!inPets) return@on
 
-            val items = packet.items
-            val possiblyForge = items.getOrNull(10)
-            if (possiblyForge != null && ItemUtils.skyblockId(possiblyForge) == "BEJEWELED_COLLAR") {
-                inPets = false
-                currentPetSlot = -1
-                return@on
-            }
+                    for (idx in 0..<45) {
+                        val itemStack = items.getOrNull(idx) ?: continue
+                        if (!isSelectedPet(itemStack)) continue
 
-            for (idx in 0..<45) {
-                val itemStack = items.getOrNull(idx) ?: continue
-                if (itemStack.item != Items.PLAYER_HEAD || itemStack == ItemStack.EMPTY) continue
+                        currentPetSlot = idx
+                    }
+                }
 
-                val lore = ItemUtils.lore(itemStack) ?: return@on
-                if (!lore.any { it == "Click to despawn!" }) continue
+                is ClientboundContainerSetSlotPacket -> {
+                    if (!inPets) return@on
+                    val slot = packet.slot
+                    if (slot !in 0..<45) return@on
 
-                currentPetSlot = idx
+                    if (isSelectedPet(packet.item)) {
+                        currentPetSlot = slot
+                        return@on
+                    }
+                    if (slot == currentPetSlot) currentPetSlot = -1
+                }
             }
         }
 
@@ -87,5 +101,11 @@ object ShowSelectedPet : Feature(
     override fun onWorldChange(event: WorldChangeEvent) {
         inPets = false
         currentPetSlot = -1
+    }
+
+    private fun isSelectedPet(itemStack: ItemStack): Boolean {
+        if (itemStack.item != Items.PLAYER_HEAD || itemStack == ItemStack.EMPTY) return false
+        val lore = ItemUtils.lore(itemStack) ?: return false
+        return lore.any { it == SELECTED_PET_LORE }
     }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/hud/texthud/Alert.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/hud/texthud/Alert.kt
@@ -4,9 +4,11 @@ import com.github.synnerz.devonian.Devonian
 import com.github.synnerz.devonian.api.Scheduler
 import com.github.synnerz.devonian.api.events.EventBus
 import com.github.synnerz.devonian.api.events.RenderOverlayEvent
+import com.github.synnerz.devonian.commands.DevonianCommand
 import com.github.synnerz.devonian.utils.BoundingBox
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.sounds.SoundEvents
+import kotlin.math.min
 
 object Alert : StylizedTextHud("internal_devonian_alert") {
     private val soundEvent = SoundEvents.ANVIL_PLACE
@@ -47,7 +49,7 @@ object Alert : StylizedTextHud("internal_devonian_alert") {
 
         val f = getBounds().fitInside(bb).first.toFloat()
         if (f != 1f) {
-            scale *= f
+            scale = min(5f, scale * f)
             (renderer as? BImgTextHudRenderer)?.invalidate()
             super.update()
         }
@@ -67,6 +69,18 @@ object Alert : StylizedTextHud("internal_devonian_alert") {
             if (t > clearTime) clearTime = 0L
             else draw(event.ctx)
         }
+
+        DevonianCommand.command.subcommand("alert") { _, args ->
+            show(
+                args[0] as String,
+                args.getOrNull(1) as Int? ?: 1000,
+                args.getOrNull(2) as Boolean? ?: true,
+            )
+            return@subcommand 1
+        }
+            .string("msg")
+            .integer("time", 0)
+            .bool("sound")
 
         anchor = Anchor.Center
         align = Align.Center

--- a/src/main/kotlin/com/github/synnerz/devonian/utils/StringUtils.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/utils/StringUtils.kt
@@ -8,7 +8,7 @@ import java.text.NumberFormat
 import java.util.*
 
 object StringUtils {
-    private val removeCodesRegex = "[\\u00a7&][0-9a-fk-or]".toRegex()
+    private val removeCodesRegex = "[\\u00a7&][0-9a-fk-or]".toRegex(RegexOption.IGNORE_CASE)
     private val romanValues = mapOf(
         'I' to 1,
         'V' to 5,

--- a/src/main/kotlin/com/github/synnerz/devonian/utils/math/MathUtils.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/utils/math/MathUtils.kt
@@ -259,4 +259,78 @@ object MathUtils {
         val expr = (M1 * sqrt_sigma / 2) / (1 + M2 * sigma * exp(M3 * sqrt_sigma))
         return -1 - sigma - (2 / M1) * (1 - 1 / (1 + expr))
     }
+
+
+    fun fitLine3D(x: List<Double>, y: List<Double>, z: List<Double>): Array<DoubleArray> {
+        if (x.size != y.size || y.size != z.size) throw IllegalArgumentException("inputs not same size")
+
+        val mx = x.sum() / x.size
+        val my = y.sum() / y.size
+        val mz = z.sum() / z.size
+
+        val XT = Matrix(arrayOf(x.toDoubleArray(), y.toDoubleArray(), z.toDoubleArray()))
+        val PX = Matrix(Array(x.size) { doubleArrayOf(x[it] - mx, y[it] - my, z[it] - mz) })
+        val M = XT.mult(PX)
+
+        var b_k = Matrix(arrayOf(doubleArrayOf(1.0), doubleArrayOf(0.0), doubleArrayOf(0.0)))
+        var iter = 50
+        while (--iter >= 0) {
+            val v = M.mult(b_k)
+
+            val vx = v[0][0]
+            val vy = v[1][0]
+            val vz = v[2][0]
+            val l2norm = sqrt(vx * vx + vy * vy + vz * vz)
+            if (l2norm < 1e-12) break
+
+            val b_k1 = v.scale(1.0 / l2norm)
+
+            var diff = 0.0
+            for (r in 0 until 3) {
+                diff = max(diff, abs(b_k[r][0] - b_k1[r][0]))
+            }
+
+            b_k = b_k1
+
+            if (diff < 1e-10) break
+        }
+
+        return arrayOf(
+            doubleArrayOf(mx, b_k[0][0]),
+            doubleArrayOf(my, b_k[1][0]),
+            doubleArrayOf(mz, b_k[2][0]),
+        )
+    }
+
+    data class LinearRegressionResult(val r: Double, val b: Double, val a: Double)
+
+    fun linReg(x: List<Double>, y: List<Double>): LinearRegressionResult? {
+        if (x.size != y.size) throw IllegalArgumentException("inputs not same size")
+        if (x.size < 2) return null
+
+        val mx = x.sum() / x.size
+        val my = y.sum() / y.size
+
+        var xStd = 0.0
+        var yStd = 0.0
+        var r = 0.0
+        for (i in x.indices) {
+            val dx = (x[i] - mx)
+            val dy = (y[i] - my)
+            xStd += dx * dx
+            yStd += dy * dy
+            r += dx * dy
+        }
+
+        xStd = sqrt(xStd)
+        yStd = sqrt(yStd)
+        if (xStd == 0.0) return null
+        if (yStd == 0.0) return LinearRegressionResult(1.0, 0.0, my)
+        r /= (xStd * yStd)
+
+        val b = r * yStd / xStd
+        val a = my - b * mx
+
+        return LinearRegressionResult(r, b, a)
+    }
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/utils/math/MathUtils.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/utils/math/MathUtils.kt
@@ -19,8 +19,8 @@ object MathUtils {
         try {
             val INV_XT_X = XT_X.invert()
             val C = INV_XT_X.mult(XT_Y)
-            return DoubleArray(C.rows) { C.arr[it][0] }
-        } catch (ignored: Exception) {
+            return DoubleArray(C.rows) { C[it][0] }
+        } catch (_: Exception) {
             return null
         }
     }

--- a/src/main/kotlin/com/github/synnerz/devonian/utils/math/Matrix.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/utils/math/Matrix.kt
@@ -67,4 +67,6 @@ class Matrix(val arr: Array<DoubleArray>, val rows: Int, val cols: Int) {
         return Matrix(inverse)
 
     }
+
+    operator fun get(i: Int) = arr[i]
 }

--- a/src/main/kotlin/com/github/synnerz/devonian/utils/math/Matrix.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/utils/math/Matrix.kt
@@ -5,6 +5,15 @@ class Matrix(val arr: Array<DoubleArray>, val rows: Int, val cols: Int) {
     constructor(rows: Int, cols: Int) : this(Array(rows) { DoubleArray(cols) }, rows, cols)
     constructor(arr: Array<DoubleArray>) : this(arr, arr.size, arr[0].size)
 
+    fun scale(f: Double) = apply {
+        for (r in 0 until rows) {
+            val row = arr[r]
+            for (c in 0 until cols) {
+                row[c] *= f
+            }
+        }
+    }
+
     fun transpose(): Matrix {
         val dst = Matrix(cols, rows)
         for (r in 0 until rows) {

--- a/src/main/resources/devonian.mixins.json
+++ b/src/main/resources/devonian.mixins.json
@@ -46,6 +46,7 @@
     "accessor.CameraAccessor",
     "accessor.ChatComponentAccessor",
     "accessor.GlDeviceAccessor",
+    "accessor.GlTextureAccessor",
     "accessor.GuiAccessor",
     "accessor.GuiGraphicsAccessor",
     "accessor.HeartTypeAccessor",

--- a/src/main/resources/devonian.mixins.json
+++ b/src/main/resources/devonian.mixins.json
@@ -67,6 +67,7 @@
     "accessor.AbstractArrowAccessor",
     "accessor.ClientboundEntityEventPacketAccessor",
     "accessor.ClientboundGameEventPacket$TypeAccessor",
+    "accessor.ClientboundMoveEntityPacketAccessor",
     "accessor.EntityAccessor"
   ]
 }

--- a/src/main/resources/devonian.mixins.json
+++ b/src/main/resources/devonian.mixins.json
@@ -26,6 +26,7 @@
     "ItemClusterRenderStateMixin",
     "ItemInHandRendererMixin",
     "KeyboardHandlerMixin",
+    "KeyboardInputMixin",
     "LightningBoltRendererMixin",
     "LivingEntityMixin",
     "LocalPlayerMixin",

--- a/src/scripts/packetloggerfilter.html
+++ b/src/scripts/packetloggerfilter.html
@@ -81,6 +81,8 @@
 
     <form id="checkboxForm">
       <button type="button" onclick="selectAll()">Select All</button>
+      <button type="button" onclick="selectAllServerbound()">Select All Serverbound</button>
+      <button type="button" onclick="selectAllClientbound()">Select All Clientbound</button>
       <button type="button" onclick="deselectAll()">Deselect All</button>
       <div style="margin: 20px;">
         <div id="checkboxContainerServer"></div>
@@ -93,6 +95,16 @@
   <script>
     function selectAll() {
       const checkboxes = document.querySelectorAll('#checkboxForm input[type="checkbox"]');
+      checkboxes.forEach(cb => cb.checked = true);
+    }
+
+    function selectAllServerbound() {
+      const checkboxes = document.querySelectorAll('#checkboxContainerServer input[type="checkbox"]');
+      checkboxes.forEach(cb => cb.checked = true);
+    }
+
+    function selectAllClientbound() {
+      const checkboxes = document.querySelectorAll('#checkboxContainerClient input[type="checkbox"]');
       checkboxes.forEach(cb => cb.checked = true);
     }
 


### PR DESCRIPTION
- Replace mutableListOf with CopyOnWriteArraySet in CroesusHighlightUnopened, PartyFinderHighlight, and HighlightSellableItems
- Remove unnecessary Scheduler.scheduleTask calls for thread-safe operations
- Extract slot update logic into private functions for better readability
- Add ClientboundContainerSetSlotPacket handling for real-time updates
- Improve performance by using thread-safe collections instead of scheduled tasks