### PR TITLE
Fix BoxStarMob fill rendering with phase ESP

### DIFF
--- a/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/clear/BoxStarMob.kt
+++ b/src/main/kotlin/com/github/synnerz/devonian/features/dungeons/clear/BoxStarMob.kt
@@ -226,7 +226,7 @@ object BoxStarMob : Feature(
                     data.color.let {
                         Color(it.red, it.green, it.blue, (SETTING_FILL_ALPHA.get() * 255.0).toInt())
                     },
-                    phase = false,
+                    phase = SETTING_PHASE,
                     centered = true,
                 )
                 false


### PR DESCRIPTION
This fixes `Box Star Mob` so the fill now respects the phase setting and shows up correctly with phased ESP.